### PR TITLE
improved docker image creation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+.git/


### PR DESCRIPTION
* seperation of concerns/containers (build vs. runtime)
  results in much smaller runtime container (down to ~25MB from ~500MB)
* use official golang build environment, instead of homebrew
* use the already existing and copied sources, instead of redownloading them
  from github.
* reorderd build steps to better leverage build cache
* also added ca-root-certificates to runtime container to fix this error:
   Error getting version file from Github:
   Get https://raw.githubusercontent.com/mailslurper/mailslurper/master/cmd/mailslurper/version.json:
   x509: failed to load system roots and no roots provided
   who=AdminController