### PR TITLE
Reverse Proxy Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,10 @@ RUN apk add --no-cache ca-certificates \
  && echo -e '{\n\
   "wwwAddress": "0.0.0.0",\n\
   "wwwPort": 8080,\n\
+  "wwwPublicURL": "",\n\
   "serviceAddress": "0.0.0.0",\n\
   "servicePort": 8085,\n\
+  "servicePublicURL": "",\n\
   "smtpAddress": "0.0.0.0",\n\
   "smtpPort": 2500,\n\
   "dbEngine": "SQLite",\n\

--- a/cmd/mailslurper/config.json
+++ b/cmd/mailslurper/config.json
@@ -1,8 +1,10 @@
 {
 	"wwwAddress": "localhost",
 	"wwwPort": 8080,
+	"wwwPublicURL": "",
 	"serviceAddress": "localhost",
 	"servicePort": 8085,
+	"servicePublicURL": "",
 	"smtpAddress": "localhost",
 	"smtpPort": 2500,
 	"dbEngine": "SQLite",

--- a/cmd/mailslurper/controllers/AdminController.go
+++ b/cmd/mailslurper/controllers/AdminController.go
@@ -145,9 +145,7 @@ func (c *AdminController) GetServiceSettings(ctx echo.Context) error {
 
 	settings := mailslurper.ServiceSettings{
 		AuthenticationScheme: c.Config.AuthenticationScheme,
-		IsSSL:                c.Config.IsServiceSSL(),
-		ServiceAddress:       c.Config.ServiceAddress,
-		ServicePort:          c.Config.ServicePort,
+		URL:                  c.Config.GetPublicServiceURL(),
 		Version:              c.ServerVersion,
 	}
 

--- a/cmd/mailslurper/controllers/AdminController.go
+++ b/cmd/mailslurper/controllers/AdminController.go
@@ -99,8 +99,8 @@ Login renders the login page
 */
 func (c *AdminController) Login(ctx echo.Context) error {
 	data := mailslurper.Page{
-		PublicWWWRoot: c.Config.GetPublicWWWRoot(),
-		Theme:         c.Config.GetTheme(),
+		PublicWWWURL: c.Config.GetPublicWWWURL(),
+		Theme:        c.Config.GetTheme(),
 	}
 
 	if ctx.QueryParam("message") != "" {

--- a/cmd/mailslurper/controllers/AdminController.go
+++ b/cmd/mailslurper/controllers/AdminController.go
@@ -42,9 +42,10 @@ func (c *AdminController) Admin(ctx echo.Context) error {
 	context := contexts.GetAdminContext(ctx)
 
 	data := mailslurper.Page{
-		Theme: c.Config.GetTheme(),
-		Title: "Admin",
-		User:  context.User,
+		PublicWWWURL: c.Config.GetPublicWWWURL(),
+		Theme:        c.Config.GetTheme(),
+		Title:        "Admin",
+		User:         context.User,
 	}
 
 	return context.Render(http.StatusOK, "mainLayout:admin", data)
@@ -86,9 +87,10 @@ func (c *AdminController) Index(ctx echo.Context) error {
 	context := contexts.GetAdminContext(ctx)
 
 	data := mailslurper.Page{
-		Theme: c.Config.GetTheme(),
-		Title: "Mail",
-		User:  context.User,
+		PublicWWWURL: c.Config.GetPublicWWWURL(),
+		Theme:        c.Config.GetTheme(),
+		Title:        "Mail",
+		User:         context.User,
 	}
 
 	return context.Render(http.StatusOK, "mainLayout:index", data)
@@ -118,9 +120,10 @@ func (c *AdminController) ManageSavedSearches(ctx echo.Context) error {
 	context := contexts.GetAdminContext(ctx)
 
 	data := mailslurper.Page{
-		Theme: c.Config.GetTheme(),
-		Title: "Manage Saved Searches",
-		User:  context.User,
+		PublicWWWURL: c.Config.GetPublicWWWURL(),
+		Theme:        c.Config.GetTheme(),
+		Title:        "Manage Saved Searches",
+		User:         context.User,
 	}
 
 	return context.Render(http.StatusOK, "mainLayout:manageSavedSearches", data)

--- a/cmd/mailslurper/controllers/AdminController.go
+++ b/cmd/mailslurper/controllers/AdminController.go
@@ -99,7 +99,8 @@ Login renders the login page
 */
 func (c *AdminController) Login(ctx echo.Context) error {
 	data := mailslurper.Page{
-		Theme: c.Config.GetTheme(),
+		PublicWWWRoot: c.Config.GetPublicWWWRoot(),
+		Theme:         c.Config.GetTheme(),
 	}
 
 	if ctx.QueryParam("message") != "" {

--- a/cmd/mailslurper/www/mailslurper/js/app.js
+++ b/cmd/mailslurper/www/mailslurper/js/app.js
@@ -3,6 +3,8 @@
 // that can be found in the LICENSE file.
 
 $(document).ready(function () {
+	var appURL = window.SettingsService.getAppURL();
+	
 	if (!window.SettingsService.serviceSettingsExistInLocalStore()) {
 		window.SettingsService.getServiceSettings()
 			.then(function (serviceSettings) {
@@ -12,7 +14,7 @@ $(document).ready(function () {
 			.then(function (serviceSettings) {
 				if (serviceSettings.authenticationScheme !== "") {
 					if (!window.AuthService.tokenExistsInStorage()) {
-						window.location = "/login";
+						window.location = appURL + "/login";
 					}
 				}
 			})
@@ -26,7 +28,7 @@ $(document).ready(function () {
 		$("#logOutLink").on("click", function () {
 			window.AuthService.logout(serviceURL)
 				.then(function () {
-					window.location = "/logout";
+					window.location = appURL + "/logout";
 				})
 				.catch(function (err) {
 					alert("There was an error logging out: " + err)

--- a/cmd/mailslurper/www/mailslurper/js/app.js
+++ b/cmd/mailslurper/www/mailslurper/js/app.js
@@ -21,8 +21,7 @@ $(document).ready(function () {
 				window.AlertService.logMessage(err, "error");
 			});
 	} else {
-		var serviceSettings = window.SettingsService.retrieveSettings();
-		var serviceURL = window.SettingsService.getServiceURL(serviceSettings);
+		var serviceURL = window.SettingsService.getServiceURL();
 
 		$("#logOutLink").on("click", function () {
 			window.AuthService.logout(serviceURL)

--- a/cmd/mailslurper/www/mailslurper/js/controllers/AdminController.js
+++ b/cmd/mailslurper/www/mailslurper/js/controllers/AdminController.js
@@ -172,7 +172,7 @@
 	var adminPruneTemplate;
 	var adminSettings;
 
-	var serviceURL = window.SettingsService.getServiceURL(window.SettingsService.retrieveServiceSettings());
+	var serviceURL = window.SettingsService.getServiceURL();
 	var pruneOptions = [];
 	var currentTheme = "";
 

--- a/cmd/mailslurper/www/mailslurper/js/controllers/AdminController.js
+++ b/cmd/mailslurper/www/mailslurper/js/controllers/AdminController.js
@@ -127,7 +127,8 @@
 		window.SettingsService.storeSettings(settings)
 			.then(function () {
 				if (settings.theme != currentTheme) {
-					window.location = "/admin";
+					var appURL = window.SettingsService.getAppURL();
+					window.location = appURL + "/admin";
 					return;
 				}
 

--- a/cmd/mailslurper/www/mailslurper/js/controllers/HomeController.js
+++ b/cmd/mailslurper/www/mailslurper/js/controllers/HomeController.js
@@ -523,7 +523,7 @@
 	var mailListTemplate = null;
 	var searchMailModalTemplate = null;
 
-	var serviceURL = window.SettingsService.getServiceURL(window.SettingsService.retrieveServiceSettings());
+	var serviceURL = window.SettingsService.getServiceURL();
 
 	window.AlertService.block("Loading");
 

--- a/cmd/mailslurper/www/mailslurper/js/controllers/LoginController.js
+++ b/cmd/mailslurper/www/mailslurper/js/controllers/LoginController.js
@@ -55,7 +55,8 @@
 				$("#frmLogin").submit();
 			})
 			.catch(function (err) {
-				window.location = "/login?message=Invalid user name or password";
+				var appURL = window.SettingsService.getAppURL();
+				window.location = appURL + "/login?message=Invalid user name or password";
 			});
 	}
 

--- a/cmd/mailslurper/www/mailslurper/js/controllers/LoginController.js
+++ b/cmd/mailslurper/www/mailslurper/js/controllers/LoginController.js
@@ -47,7 +47,7 @@
 			return false;
 		}
 
-		var serviceURL = window.SettingsService.getServiceURL(serviceSettings);
+		var serviceURL = window.SettingsService.getServiceURL();
 
 		window.AuthService.login(serviceURL, getUserName(), getPassword())
 			.then(function (token) {

--- a/cmd/mailslurper/www/mailslurper/js/services/AuthService.js
+++ b/cmd/mailslurper/www/mailslurper/js/services/AuthService.js
@@ -74,6 +74,7 @@ window.AuthService = {
 	},
 
 	gotoLogin: function () {
-		window.location = "/login";
+		var appURL = window.SettingsService.getAppURL();
+		window.location = appURL + "/login";
 	}
 };

--- a/cmd/mailslurper/www/mailslurper/js/services/SettingsService.js
+++ b/cmd/mailslurper/www/mailslurper/js/services/SettingsService.js
@@ -68,14 +68,10 @@ window.SettingsService = {
 	 */
 	getServiceURL: function () {
 		var serviceSettings = window.SettingsService.retrieveServiceSettings();
-		var serviceAddress = serviceSettings.serviceAddress;
+		var serviceURL = serviceSettings.url;
 
-		if (serviceAddress === "0.0.0.0") {
-			serviceAddress = window.location.hostname;
-		}
+		serviceURL = serviceURL.replace('0.0.0.0', window.location.hostname);
 
-		var protocol = (serviceSettings.isSSL) ? "https:" : "http:";
-		var serviceURL = protocol + "//" + serviceAddress + ":" + serviceSettings.servicePort;
 		return serviceURL;
 	},
 

--- a/cmd/mailslurper/www/mailslurper/js/services/SettingsService.js
+++ b/cmd/mailslurper/www/mailslurper/js/services/SettingsService.js
@@ -76,6 +76,13 @@ window.SettingsService = {
 	},
 
 	/**
+	 * getWWURL return the fully formatted app URL
+	 */
+	getAppURL: function () {
+		return $('meta[name=app-url]').attr('content')
+	},
+
+	/**
 	 * retrieveSavedSearches reads saved searches from local storage
 	 */
 	retrieveSavedSearches: function () {

--- a/cmd/mailslurper/www/mailslurper/js/services/SettingsService.js
+++ b/cmd/mailslurper/www/mailslurper/js/services/SettingsService.js
@@ -66,7 +66,7 @@ window.SettingsService = {
 	/**
 	 * getServiceURL returns a fully formatted service URL
 	 */
-	getServiceURL: function (serviceSettings) {
+	getServiceURL: function () {
 		var serviceSettings = window.SettingsService.retrieveServiceSettings();
 		var serviceAddress = serviceSettings.serviceAddress;
 

--- a/cmd/mailslurper/www/mailslurper/js/services/TemplateService.js
+++ b/cmd/mailslurper/www/mailslurper/js/services/TemplateService.js
@@ -7,7 +7,8 @@
 window.TemplateService = {
 	load: function (name) {
 		return new Promise(function (resolve, reject) {
-			$.get("/www/mailslurper/templates/" + name + ".hbs").then(
+			var appURL = window.SettingsService.getAppURL();
+			$.get(appURL + "/www/mailslurper/templates/" + name + ".hbs").then(
 				function (result) {
 					return resolve(result);
 				},

--- a/cmd/mailslurper/www/mailslurper/js/widgets/SavedSearchesWidget.js
+++ b/cmd/mailslurper/www/mailslurper/js/widgets/SavedSearchesWidget.js
@@ -30,7 +30,8 @@
 						label: "Manage",
 						cssClass: "btn-default",
 						action: function () {
-							window.location = "/savedsearches";
+							var appURL = window.SettingsService.getAppURL();
+							window.location = appURL + "/savedsearches";
 						}
 					},
 					{

--- a/cmd/mailslurper/www/mailslurper/layouts/loginLayout.gohtml
+++ b/cmd/mailslurper/www/mailslurper/layouts/loginLayout.gohtml
@@ -13,17 +13,17 @@
 	<meta name="description" content="MailSlurper Server - Slurps mail into oblivion!" />
 	<meta name="author" content="Adam Presley <adam@adampresley.com>" />
 
-	<link rel="icon" href="/www/mailslurper/images/favicon.ico" />
+	<link rel="icon" href="{{PublicWWWRoot}}/mailslurper/images/favicon.ico" />
 
 	<title>Login // MailSlurper</title>
 
-	<link href="/www/mailslurper/themes/{{.Theme}}/bootstrap.css" rel="stylesheet" id="themeBootstrapStylesheet" />
-	<link href="/www/fontawesome/css/font-awesome.css" rel="stylesheet" />
-	<link href="/www/lightbox2/css/lightbox.css" rel="stylesheet" />
-	<link href="/www/bootstrap-dialog/css/bootstrap-dialog.css" rel="stylesheet" />
-	<link href="/www/bootstrap-daterangepicker/daterangepicker.css" rel="stylesheet" />
-	<link href="/www/mailslurper/themes/{{.Theme}}/style.css" rel="stylesheet" id="themeStylesheet" />
-	<link href="/www/mailslurper/css/login.css" rel="stylesheet" />
+	<link href="{{PublicWWWRoot}}/mailslurper/themes/{{.Theme}}/bootstrap.css" rel="stylesheet" id="themeBootstrapStylesheet" />
+	<link href="{{PublicWWWRoot}}/fontawesome/css/font-awesome.css" rel="stylesheet" />
+	<link href="{{PublicWWWRoot}}/lightbox2/css/lightbox.css" rel="stylesheet" />
+	<link href="{{PublicWWWRoot}}/bootstrap-dialog/css/bootstrap-dialog.css" rel="stylesheet" />
+	<link href="{{PublicWWWRoot}}/bootstrap-daterangepicker/daterangepicker.css" rel="stylesheet" />
+	<link href="{{PublicWWWRoot}}/mailslurper/themes/{{.Theme}}/style.css" rel="stylesheet" id="themeStylesheet" />
+	<link href="{{PublicWWWRoot}}/mailslurper/css/login.css" rel="stylesheet" />
 </head>
 
 <body>
@@ -33,18 +33,18 @@
 	<!-- /.container -->
 </body>
 
-<script src="/www/npo/npo.js"></script>
-<script src="/www/moment/moment.js"></script>
-<script src="/www/handlebars/handlebars.js"></script>
-<script src="/www/jquery/jquery.js"></script>
-<script src="/www/blockui/jquery.blockUI.js"></script>
-<script src="/www/bootstrap/js/bootstrap.js"></script>
-<script src="/www/bootstrap-daterangepicker/daterangepicker.js"></script>
-<script src="/www/bootstrap-dialog/js/bootstrap-dialog.js"></script>
-<script src="/www/bootstrap-growl/jquery.bootstrap-growl.js"></script>
-<script src="/www/lightbox2/js/lightbox.js"></script>
-<script src="/www/mailslurper/js/services/SettingsService.js"></script>
-<script src="/www/mailslurper/js/services/AuthService.js"></script>
+<script src="{{PublicWWWRoot}}/npo/npo.js"></script>
+<script src="{{PublicWWWRoot}}/moment/moment.js"></script>
+<script src="{{PublicWWWRoot}}/handlebars/handlebars.js"></script>
+<script src="{{PublicWWWRoot}}/jquery/jquery.js"></script>
+<script src="{{PublicWWWRoot}}/blockui/jquery.blockUI.js"></script>
+<script src="{{PublicWWWRoot}}/bootstrap/js/bootstrap.js"></script>
+<script src="{{PublicWWWRoot}}/bootstrap-daterangepicker/daterangepicker.js"></script>
+<script src="{{PublicWWWRoot}}/bootstrap-dialog/js/bootstrap-dialog.js"></script>
+<script src="{{PublicWWWRoot}}/bootstrap-growl/jquery.bootstrap-growl.js"></script>
+<script src="{{PublicWWWRoot}}/lightbox2/js/lightbox.js"></script>
+<script src="{{PublicWWWRoot}}/mailslurper/js/services/SettingsService.js"></script>
+<script src="{{PublicWWWRoot}}/mailslurper/js/services/AuthService.js"></script>
 
 {{template "js" .}}
 

--- a/cmd/mailslurper/www/mailslurper/layouts/loginLayout.gohtml
+++ b/cmd/mailslurper/www/mailslurper/layouts/loginLayout.gohtml
@@ -13,17 +13,17 @@
 	<meta name="description" content="MailSlurper Server - Slurps mail into oblivion!" />
 	<meta name="author" content="Adam Presley <adam@adampresley.com>" />
 
-	<link rel="icon" href="{{PublicWWWRoot}}/mailslurper/images/favicon.ico" />
+	<link rel="icon" href="{{PublicWWWURL}}/mailslurper/images/favicon.ico" />
 
 	<title>Login // MailSlurper</title>
 
-	<link href="{{PublicWWWRoot}}/mailslurper/themes/{{.Theme}}/bootstrap.css" rel="stylesheet" id="themeBootstrapStylesheet" />
-	<link href="{{PublicWWWRoot}}/fontawesome/css/font-awesome.css" rel="stylesheet" />
-	<link href="{{PublicWWWRoot}}/lightbox2/css/lightbox.css" rel="stylesheet" />
-	<link href="{{PublicWWWRoot}}/bootstrap-dialog/css/bootstrap-dialog.css" rel="stylesheet" />
-	<link href="{{PublicWWWRoot}}/bootstrap-daterangepicker/daterangepicker.css" rel="stylesheet" />
-	<link href="{{PublicWWWRoot}}/mailslurper/themes/{{.Theme}}/style.css" rel="stylesheet" id="themeStylesheet" />
-	<link href="{{PublicWWWRoot}}/mailslurper/css/login.css" rel="stylesheet" />
+	<link href="{{PublicWWWURL}}/mailslurper/themes/{{.Theme}}/bootstrap.css" rel="stylesheet" id="themeBootstrapStylesheet" />
+	<link href="{{PublicWWWURL}}/fontawesome/css/font-awesome.css" rel="stylesheet" />
+	<link href="{{PublicWWWURL}}/lightbox2/css/lightbox.css" rel="stylesheet" />
+	<link href="{{PublicWWWURL}}/bootstrap-dialog/css/bootstrap-dialog.css" rel="stylesheet" />
+	<link href="{{PublicWWWURL}}/bootstrap-daterangepicker/daterangepicker.css" rel="stylesheet" />
+	<link href="{{PublicWWWURL}}/mailslurper/themes/{{.Theme}}/style.css" rel="stylesheet" id="themeStylesheet" />
+	<link href="{{PublicWWWURL}}/mailslurper/css/login.css" rel="stylesheet" />
 </head>
 
 <body>
@@ -33,18 +33,18 @@
 	<!-- /.container -->
 </body>
 
-<script src="{{PublicWWWRoot}}/npo/npo.js"></script>
-<script src="{{PublicWWWRoot}}/moment/moment.js"></script>
-<script src="{{PublicWWWRoot}}/handlebars/handlebars.js"></script>
-<script src="{{PublicWWWRoot}}/jquery/jquery.js"></script>
-<script src="{{PublicWWWRoot}}/blockui/jquery.blockUI.js"></script>
-<script src="{{PublicWWWRoot}}/bootstrap/js/bootstrap.js"></script>
-<script src="{{PublicWWWRoot}}/bootstrap-daterangepicker/daterangepicker.js"></script>
-<script src="{{PublicWWWRoot}}/bootstrap-dialog/js/bootstrap-dialog.js"></script>
-<script src="{{PublicWWWRoot}}/bootstrap-growl/jquery.bootstrap-growl.js"></script>
-<script src="{{PublicWWWRoot}}/lightbox2/js/lightbox.js"></script>
-<script src="{{PublicWWWRoot}}/mailslurper/js/services/SettingsService.js"></script>
-<script src="{{PublicWWWRoot}}/mailslurper/js/services/AuthService.js"></script>
+<script src="{{PublicWWWURL}}/npo/npo.js"></script>
+<script src="{{PublicWWWURL}}/moment/moment.js"></script>
+<script src="{{PublicWWWURL}}/handlebars/handlebars.js"></script>
+<script src="{{PublicWWWURL}}/jquery/jquery.js"></script>
+<script src="{{PublicWWWURL}}/blockui/jquery.blockUI.js"></script>
+<script src="{{PublicWWWURL}}/bootstrap/js/bootstrap.js"></script>
+<script src="{{PublicWWWURL}}/bootstrap-daterangepicker/daterangepicker.js"></script>
+<script src="{{PublicWWWURL}}/bootstrap-dialog/js/bootstrap-dialog.js"></script>
+<script src="{{PublicWWWURL}}/bootstrap-growl/jquery.bootstrap-growl.js"></script>
+<script src="{{PublicWWWURL}}/lightbox2/js/lightbox.js"></script>
+<script src="{{PublicWWWURL}}/mailslurper/js/services/SettingsService.js"></script>
+<script src="{{PublicWWWURL}}/mailslurper/js/services/AuthService.js"></script>
 
 {{template "js" .}}
 

--- a/cmd/mailslurper/www/mailslurper/layouts/loginLayout.gohtml
+++ b/cmd/mailslurper/www/mailslurper/layouts/loginLayout.gohtml
@@ -13,17 +13,19 @@
 	<meta name="description" content="MailSlurper Server - Slurps mail into oblivion!" />
 	<meta name="author" content="Adam Presley <adam@adampresley.com>" />
 
-	<link rel="icon" href="{{PublicWWWURL}}/mailslurper/images/favicon.ico" />
+	<meta name="app-url" content="{{.PublicWWWURL}}" />
+
+	<link rel="icon" href="{{.PublicWWWURL}}/www/mailslurper/images/favicon.ico" />
 
 	<title>Login // MailSlurper</title>
 
-	<link href="{{PublicWWWURL}}/mailslurper/themes/{{.Theme}}/bootstrap.css" rel="stylesheet" id="themeBootstrapStylesheet" />
-	<link href="{{PublicWWWURL}}/fontawesome/css/font-awesome.css" rel="stylesheet" />
-	<link href="{{PublicWWWURL}}/lightbox2/css/lightbox.css" rel="stylesheet" />
-	<link href="{{PublicWWWURL}}/bootstrap-dialog/css/bootstrap-dialog.css" rel="stylesheet" />
-	<link href="{{PublicWWWURL}}/bootstrap-daterangepicker/daterangepicker.css" rel="stylesheet" />
-	<link href="{{PublicWWWURL}}/mailslurper/themes/{{.Theme}}/style.css" rel="stylesheet" id="themeStylesheet" />
-	<link href="{{PublicWWWURL}}/mailslurper/css/login.css" rel="stylesheet" />
+	<link href="{{.PublicWWWURL}}/www/mailslurper/themes/{{.Theme}}/bootstrap.css" rel="stylesheet" id="themeBootstrapStylesheet" />
+	<link href="{{.PublicWWWURL}}/www/fontawesome/css/font-awesome.css" rel="stylesheet" />
+	<link href="{{.PublicWWWURL}}/www/lightbox2/css/lightbox.css" rel="stylesheet" />
+	<link href="{{.PublicWWWURL}}/www/bootstrap-dialog/css/bootstrap-dialog.css" rel="stylesheet" />
+	<link href="{{.PublicWWWURL}}/www/bootstrap-daterangepicker/daterangepicker.css" rel="stylesheet" />
+	<link href="{{.PublicWWWURL}}/www/mailslurper/themes/{{.Theme}}/style.css" rel="stylesheet" id="themeStylesheet" />
+	<link href="{{.PublicWWWURL}}/www/mailslurper/css/login.css" rel="stylesheet" />
 </head>
 
 <body>
@@ -33,18 +35,18 @@
 	<!-- /.container -->
 </body>
 
-<script src="{{PublicWWWURL}}/npo/npo.js"></script>
-<script src="{{PublicWWWURL}}/moment/moment.js"></script>
-<script src="{{PublicWWWURL}}/handlebars/handlebars.js"></script>
-<script src="{{PublicWWWURL}}/jquery/jquery.js"></script>
-<script src="{{PublicWWWURL}}/blockui/jquery.blockUI.js"></script>
-<script src="{{PublicWWWURL}}/bootstrap/js/bootstrap.js"></script>
-<script src="{{PublicWWWURL}}/bootstrap-daterangepicker/daterangepicker.js"></script>
-<script src="{{PublicWWWURL}}/bootstrap-dialog/js/bootstrap-dialog.js"></script>
-<script src="{{PublicWWWURL}}/bootstrap-growl/jquery.bootstrap-growl.js"></script>
-<script src="{{PublicWWWURL}}/lightbox2/js/lightbox.js"></script>
-<script src="{{PublicWWWURL}}/mailslurper/js/services/SettingsService.js"></script>
-<script src="{{PublicWWWURL}}/mailslurper/js/services/AuthService.js"></script>
+<script src="{{.PublicWWWURL}}/www/npo/npo.js"></script>
+<script src="{{.PublicWWWURL}}/www/moment/moment.js"></script>
+<script src="{{.PublicWWWURL}}/www/handlebars/handlebars.js"></script>
+<script src="{{.PublicWWWURL}}/www/jquery/jquery.js"></script>
+<script src="{{.PublicWWWURL}}/www/blockui/jquery.blockUI.js"></script>
+<script src="{{.PublicWWWURL}}/www/bootstrap/js/bootstrap.js"></script>
+<script src="{{.PublicWWWURL}}/www/bootstrap-daterangepicker/daterangepicker.js"></script>
+<script src="{{.PublicWWWURL}}/www/bootstrap-dialog/js/bootstrap-dialog.js"></script>
+<script src="{{.PublicWWWURL}}/www/bootstrap-growl/jquery.bootstrap-growl.js"></script>
+<script src="{{.PublicWWWURL}}/www/lightbox2/js/lightbox.js"></script>
+<script src="{{.PublicWWWURL}}/www/mailslurper/js/services/SettingsService.js"></script>
+<script src="{{.PublicWWWURL}}/www/mailslurper/js/services/AuthService.js"></script>
 
 {{template "js" .}}
 

--- a/cmd/mailslurper/www/mailslurper/layouts/mainLayout.gohtml
+++ b/cmd/mailslurper/www/mailslurper/layouts/mainLayout.gohtml
@@ -13,17 +13,17 @@
 	<meta name="description" content="MailSlurper Server - Slurps mail into oblivion!" />
 	<meta name="author" content="Adam Presley <adam@adampresley.com>" />
 
-	<link rel="icon" href="{{PublicWWWRoot}}/mailslurper/images/favicon.ico" />
+	<link rel="icon" href="{{PublicWWWURL}}/mailslurper/images/favicon.ico" />
 
 	<title>{{.Title}} // MailSlurper</title>
 
-	<link href="{{PublicWWWRoot}}/mailslurper/themes/{{.Theme}}/bootstrap.css" rel="stylesheet" id="themeBootstrapStylesheet" />
-	<link href="{{PublicWWWRoot}}/fontawesome/css/font-awesome.css" rel="stylesheet" />
-	<link href="{{PublicWWWRoot}}/lightbox2/css/lightbox.css" rel="stylesheet" />
-	<link href="{{PublicWWWRoot}}/bootstrap-dialog/css/bootstrap-dialog.css" rel="stylesheet" />
-	<link href="{{PublicWWWRoot}}/bootstrap-daterangepicker/daterangepicker.css" rel="stylesheet" />
-	<link href="{{PublicWWWRoot}}/mailslurper/css/style.css" rel="stylesheet" />
-	<link href="{{PublicWWWRoot}}/mailslurper/themes/{{.Theme}}/style.css" rel="stylesheet" id="themeStylesheet" />
+	<link href="{{PublicWWWURL}}/mailslurper/themes/{{.Theme}}/bootstrap.css" rel="stylesheet" id="themeBootstrapStylesheet" />
+	<link href="{{PublicWWWURL}}/fontawesome/css/font-awesome.css" rel="stylesheet" />
+	<link href="{{PublicWWWURL}}/lightbox2/css/lightbox.css" rel="stylesheet" />
+	<link href="{{PublicWWWURL}}/bootstrap-dialog/css/bootstrap-dialog.css" rel="stylesheet" />
+	<link href="{{PublicWWWURL}}/bootstrap-daterangepicker/daterangepicker.css" rel="stylesheet" />
+	<link href="{{PublicWWWURL}}/mailslurper/css/style.css" rel="stylesheet" />
+	<link href="{{PublicWWWURL}}/mailslurper/themes/{{.Theme}}/style.css" rel="stylesheet" id="themeStylesheet" />
 	{{template "css" .}}
 </head>
 
@@ -38,7 +38,7 @@
 					<span class="icon-bar"></span>
 					<span class="icon-bar"></span>
 				</button>
-				<a class="navbar-brand mailSlurperLogoLink" href="/"><img src="{{PublicWWWRoot}}/mailslurper/images/logo.png" alt="MailSlurper" class="mailSlurperLogo" /></a>
+				<a class="navbar-brand mailSlurperLogoLink" href="/"><img src="{{PublicWWWURL}}/mailslurper/images/logo.png" alt="MailSlurper" class="mailSlurperLogo" /></a>
 			</div>
 
 			<div id="navbar" class="collapse navbar-collapse">
@@ -78,35 +78,35 @@
 	<!-- /.container -->
 </body>
 
-<script src="{{PublicWWWRoot}}/npo/npo.js"></script>
-<script src="{{PublicWWWRoot}}/moment/moment.js"></script>
-<script src="{{PublicWWWRoot}}/handlebars/handlebars.js"></script>
-<script src="{{PublicWWWRoot}}/mailslurper/templates/helpers/attachmentURL.js"></script>
-<script src="{{PublicWWWRoot}}/mailslurper/templates/helpers/autoRefreshSelector.js"></script>
-<script src="{{PublicWWWRoot}}/mailslurper/templates/helpers/dateFormatSelector.js"></script>
-<script src="{{PublicWWWRoot}}/mailslurper/templates/helpers/formatDateTime.js"></script>
-<script src="{{PublicWWWRoot}}/mailslurper/templates/helpers/ifIsImageAttachment.js"></script>
-<script src="{{PublicWWWRoot}}/mailslurper/templates/helpers/themeSelector.js"></script>
-<script src="{{PublicWWWRoot}}/mailslurper/templates/helpers/pageSelector.js"></script>
-<script src="{{PublicWWWRoot}}/mailslurper/templates/helpers/unescape.js"></script>
-<script src="{{PublicWWWRoot}}/jquery/jquery.js"></script>
-<script src="{{PublicWWWRoot}}/blockui/jquery.blockUI.js"></script>
-<script src="{{PublicWWWRoot}}/bootstrap/js/bootstrap.js"></script>
-<script src="{{PublicWWWRoot}}/bootstrap-daterangepicker/daterangepicker.js"></script>
-<script src="{{PublicWWWRoot}}/bootstrap-dialog/js/bootstrap-dialog.js"></script>
-<script src="{{PublicWWWRoot}}/bootstrap-growl/jquery.bootstrap-growl.js"></script>
-<script src="{{PublicWWWRoot}}/lightbox2/js/lightbox.js"></script>
+<script src="{{PublicWWWURL}}/npo/npo.js"></script>
+<script src="{{PublicWWWURL}}/moment/moment.js"></script>
+<script src="{{PublicWWWURL}}/handlebars/handlebars.js"></script>
+<script src="{{PublicWWWURL}}/mailslurper/templates/helpers/attachmentURL.js"></script>
+<script src="{{PublicWWWURL}}/mailslurper/templates/helpers/autoRefreshSelector.js"></script>
+<script src="{{PublicWWWURL}}/mailslurper/templates/helpers/dateFormatSelector.js"></script>
+<script src="{{PublicWWWURL}}/mailslurper/templates/helpers/formatDateTime.js"></script>
+<script src="{{PublicWWWURL}}/mailslurper/templates/helpers/ifIsImageAttachment.js"></script>
+<script src="{{PublicWWWURL}}/mailslurper/templates/helpers/themeSelector.js"></script>
+<script src="{{PublicWWWURL}}/mailslurper/templates/helpers/pageSelector.js"></script>
+<script src="{{PublicWWWURL}}/mailslurper/templates/helpers/unescape.js"></script>
+<script src="{{PublicWWWURL}}/jquery/jquery.js"></script>
+<script src="{{PublicWWWURL}}/blockui/jquery.blockUI.js"></script>
+<script src="{{PublicWWWURL}}/bootstrap/js/bootstrap.js"></script>
+<script src="{{PublicWWWURL}}/bootstrap-daterangepicker/daterangepicker.js"></script>
+<script src="{{PublicWWWURL}}/bootstrap-dialog/js/bootstrap-dialog.js"></script>
+<script src="{{PublicWWWURL}}/bootstrap-growl/jquery.bootstrap-growl.js"></script>
+<script src="{{PublicWWWURL}}/lightbox2/js/lightbox.js"></script>
 
-<script src="{{PublicWWWRoot}}/mailslurper/js/services/SettingsService.js"></script>
-<script src="{{PublicWWWRoot}}/mailslurper/js/services/AuthService.js"></script>
-<script src="{{PublicWWWRoot}}/mailslurper/js/services/AlertService.js"></script>
-<script src="{{PublicWWWRoot}}/mailslurper/js/services/MailService.js"></script>
-<script src="{{PublicWWWRoot}}/mailslurper/js/services/SeedService.js"></script>
-<script src="{{PublicWWWRoot}}/mailslurper/js/services/VersionService.js"></script>
-<script src="{{PublicWWWRoot}}/mailslurper/js/services/TemplateService.js"></script>
+<script src="{{PublicWWWURL}}/mailslurper/js/services/SettingsService.js"></script>
+<script src="{{PublicWWWURL}}/mailslurper/js/services/AuthService.js"></script>
+<script src="{{PublicWWWURL}}/mailslurper/js/services/AlertService.js"></script>
+<script src="{{PublicWWWURL}}/mailslurper/js/services/MailService.js"></script>
+<script src="{{PublicWWWURL}}/mailslurper/js/services/SeedService.js"></script>
+<script src="{{PublicWWWURL}}/mailslurper/js/services/VersionService.js"></script>
+<script src="{{PublicWWWURL}}/mailslurper/js/services/TemplateService.js"></script>
 
-<script src="{{PublicWWWRoot}}/mailslurper/js/widgets/SavedSearchesWidget.js"></script>
-<script src="{{PublicWWWRoot}}/mailslurper/js/app.js"></script>
+<script src="{{PublicWWWURL}}/mailslurper/js/widgets/SavedSearchesWidget.js"></script>
+<script src="{{PublicWWWURL}}/mailslurper/js/app.js"></script>
 {{template "js" .}}
 
 </html>

--- a/cmd/mailslurper/www/mailslurper/layouts/mainLayout.gohtml
+++ b/cmd/mailslurper/www/mailslurper/layouts/mainLayout.gohtml
@@ -13,17 +13,17 @@
 	<meta name="description" content="MailSlurper Server - Slurps mail into oblivion!" />
 	<meta name="author" content="Adam Presley <adam@adampresley.com>" />
 
-	<link rel="icon" href="/www/mailslurper/images/favicon.ico" />
+	<link rel="icon" href="{{PublicWWWRoot}}/mailslurper/images/favicon.ico" />
 
 	<title>{{.Title}} // MailSlurper</title>
 
-	<link href="/www/mailslurper/themes/{{.Theme}}/bootstrap.css" rel="stylesheet" id="themeBootstrapStylesheet" />
-	<link href="/www/fontawesome/css/font-awesome.css" rel="stylesheet" />
-	<link href="/www/lightbox2/css/lightbox.css" rel="stylesheet" />
-	<link href="/www/bootstrap-dialog/css/bootstrap-dialog.css" rel="stylesheet" />
-	<link href="/www/bootstrap-daterangepicker/daterangepicker.css" rel="stylesheet" />
-	<link href="/www/mailslurper/css/style.css" rel="stylesheet" />
-	<link href="/www/mailslurper/themes/{{.Theme}}/style.css" rel="stylesheet" id="themeStylesheet" />
+	<link href="{{PublicWWWRoot}}/mailslurper/themes/{{.Theme}}/bootstrap.css" rel="stylesheet" id="themeBootstrapStylesheet" />
+	<link href="{{PublicWWWRoot}}/fontawesome/css/font-awesome.css" rel="stylesheet" />
+	<link href="{{PublicWWWRoot}}/lightbox2/css/lightbox.css" rel="stylesheet" />
+	<link href="{{PublicWWWRoot}}/bootstrap-dialog/css/bootstrap-dialog.css" rel="stylesheet" />
+	<link href="{{PublicWWWRoot}}/bootstrap-daterangepicker/daterangepicker.css" rel="stylesheet" />
+	<link href="{{PublicWWWRoot}}/mailslurper/css/style.css" rel="stylesheet" />
+	<link href="{{PublicWWWRoot}}/mailslurper/themes/{{.Theme}}/style.css" rel="stylesheet" id="themeStylesheet" />
 	{{template "css" .}}
 </head>
 
@@ -38,7 +38,7 @@
 					<span class="icon-bar"></span>
 					<span class="icon-bar"></span>
 				</button>
-				<a class="navbar-brand mailSlurperLogoLink" href="/"><img src="/www/mailslurper/images/logo.png" alt="MailSlurper" class="mailSlurperLogo" /></a>
+				<a class="navbar-brand mailSlurperLogoLink" href="/"><img src="{{PublicWWWRoot}}/mailslurper/images/logo.png" alt="MailSlurper" class="mailSlurperLogo" /></a>
 			</div>
 
 			<div id="navbar" class="collapse navbar-collapse">
@@ -78,35 +78,35 @@
 	<!-- /.container -->
 </body>
 
-<script src="/www/npo/npo.js"></script>
-<script src="/www/moment/moment.js"></script>
-<script src="/www/handlebars/handlebars.js"></script>
-<script src="/www/mailslurper/templates/helpers/attachmentURL.js"></script>
-<script src="/www/mailslurper/templates/helpers/autoRefreshSelector.js"></script>
-<script src="/www/mailslurper/templates/helpers/dateFormatSelector.js"></script>
-<script src="/www/mailslurper/templates/helpers/formatDateTime.js"></script>
-<script src="/www/mailslurper/templates/helpers/ifIsImageAttachment.js"></script>
-<script src="/www/mailslurper/templates/helpers/themeSelector.js"></script>
-<script src="/www/mailslurper/templates/helpers/pageSelector.js"></script>
-<script src="/www/mailslurper/templates/helpers/unescape.js"></script>
-<script src="/www/jquery/jquery.js"></script>
-<script src="/www/blockui/jquery.blockUI.js"></script>
-<script src="/www/bootstrap/js/bootstrap.js"></script>
-<script src="/www/bootstrap-daterangepicker/daterangepicker.js"></script>
-<script src="/www/bootstrap-dialog/js/bootstrap-dialog.js"></script>
-<script src="/www/bootstrap-growl/jquery.bootstrap-growl.js"></script>
-<script src="/www/lightbox2/js/lightbox.js"></script>
+<script src="{{PublicWWWRoot}}/npo/npo.js"></script>
+<script src="{{PublicWWWRoot}}/moment/moment.js"></script>
+<script src="{{PublicWWWRoot}}/handlebars/handlebars.js"></script>
+<script src="{{PublicWWWRoot}}/mailslurper/templates/helpers/attachmentURL.js"></script>
+<script src="{{PublicWWWRoot}}/mailslurper/templates/helpers/autoRefreshSelector.js"></script>
+<script src="{{PublicWWWRoot}}/mailslurper/templates/helpers/dateFormatSelector.js"></script>
+<script src="{{PublicWWWRoot}}/mailslurper/templates/helpers/formatDateTime.js"></script>
+<script src="{{PublicWWWRoot}}/mailslurper/templates/helpers/ifIsImageAttachment.js"></script>
+<script src="{{PublicWWWRoot}}/mailslurper/templates/helpers/themeSelector.js"></script>
+<script src="{{PublicWWWRoot}}/mailslurper/templates/helpers/pageSelector.js"></script>
+<script src="{{PublicWWWRoot}}/mailslurper/templates/helpers/unescape.js"></script>
+<script src="{{PublicWWWRoot}}/jquery/jquery.js"></script>
+<script src="{{PublicWWWRoot}}/blockui/jquery.blockUI.js"></script>
+<script src="{{PublicWWWRoot}}/bootstrap/js/bootstrap.js"></script>
+<script src="{{PublicWWWRoot}}/bootstrap-daterangepicker/daterangepicker.js"></script>
+<script src="{{PublicWWWRoot}}/bootstrap-dialog/js/bootstrap-dialog.js"></script>
+<script src="{{PublicWWWRoot}}/bootstrap-growl/jquery.bootstrap-growl.js"></script>
+<script src="{{PublicWWWRoot}}/lightbox2/js/lightbox.js"></script>
 
-<script src="/www/mailslurper/js/services/SettingsService.js"></script>
-<script src="/www/mailslurper/js/services/AuthService.js"></script>
-<script src="/www/mailslurper/js/services/AlertService.js"></script>
-<script src="/www/mailslurper/js/services/MailService.js"></script>
-<script src="/www/mailslurper/js/services/SeedService.js"></script>
-<script src="/www/mailslurper/js/services/VersionService.js"></script>
-<script src="/www/mailslurper/js/services/TemplateService.js"></script>
+<script src="{{PublicWWWRoot}}/mailslurper/js/services/SettingsService.js"></script>
+<script src="{{PublicWWWRoot}}/mailslurper/js/services/AuthService.js"></script>
+<script src="{{PublicWWWRoot}}/mailslurper/js/services/AlertService.js"></script>
+<script src="{{PublicWWWRoot}}/mailslurper/js/services/MailService.js"></script>
+<script src="{{PublicWWWRoot}}/mailslurper/js/services/SeedService.js"></script>
+<script src="{{PublicWWWRoot}}/mailslurper/js/services/VersionService.js"></script>
+<script src="{{PublicWWWRoot}}/mailslurper/js/services/TemplateService.js"></script>
 
-<script src="/www/mailslurper/js/widgets/SavedSearchesWidget.js"></script>
-<script src="/www/mailslurper/js/app.js"></script>
+<script src="{{PublicWWWRoot}}/mailslurper/js/widgets/SavedSearchesWidget.js"></script>
+<script src="{{PublicWWWRoot}}/mailslurper/js/app.js"></script>
 {{template "js" .}}
 
 </html>

--- a/cmd/mailslurper/www/mailslurper/layouts/mainLayout.gohtml
+++ b/cmd/mailslurper/www/mailslurper/layouts/mainLayout.gohtml
@@ -38,23 +38,23 @@
 					<span class="icon-bar"></span>
 					<span class="icon-bar"></span>
 				</button>
-				<a class="navbar-brand mailSlurperLogoLink" href="/"><img src="{{PublicWWWURL}}/mailslurper/images/logo.png" alt="MailSlurper" class="mailSlurperLogo" /></a>
+				<a class="navbar-brand mailSlurperLogoLink" href="{{PublicWWWURL}}"><img src="{{PublicWWWURL}}/mailslurper/images/logo.png" alt="MailSlurper" class="mailSlurperLogo" /></a>
 			</div>
 
 			<div id="navbar" class="collapse navbar-collapse">
 				<ul class="nav navbar-nav">
 					<li>
-						<a href="/">
+						<a href="{{PublicWWWURL}}">
 							<i class="fa fa-home fa-lg"></i>
 						</a>
 					</li>
 					<li>
-						<a href="/savedsearches">
+						<a href="{{PublicWWWURL}}/savedsearches">
 							<i class="fa fa-filter"></i>
 						</a>
 					</li>
 					<li>
-						<a href="/admin">
+						<a href="{{PublicWWWURL}}/admin">
 							<i class="fa fa-cog"></i>
 						</a>
 					</li>

--- a/cmd/mailslurper/www/mailslurper/layouts/mainLayout.gohtml
+++ b/cmd/mailslurper/www/mailslurper/layouts/mainLayout.gohtml
@@ -13,17 +13,19 @@
 	<meta name="description" content="MailSlurper Server - Slurps mail into oblivion!" />
 	<meta name="author" content="Adam Presley <adam@adampresley.com>" />
 
-	<link rel="icon" href="{{PublicWWWURL}}/mailslurper/images/favicon.ico" />
+	<meta name="app-url" content="{{.PublicWWWURL}}" />
+
+	<link rel="icon" href="{{.PublicWWWURL}}/www/mailslurper/images/favicon.ico" />
 
 	<title>{{.Title}} // MailSlurper</title>
 
-	<link href="{{PublicWWWURL}}/mailslurper/themes/{{.Theme}}/bootstrap.css" rel="stylesheet" id="themeBootstrapStylesheet" />
-	<link href="{{PublicWWWURL}}/fontawesome/css/font-awesome.css" rel="stylesheet" />
-	<link href="{{PublicWWWURL}}/lightbox2/css/lightbox.css" rel="stylesheet" />
-	<link href="{{PublicWWWURL}}/bootstrap-dialog/css/bootstrap-dialog.css" rel="stylesheet" />
-	<link href="{{PublicWWWURL}}/bootstrap-daterangepicker/daterangepicker.css" rel="stylesheet" />
-	<link href="{{PublicWWWURL}}/mailslurper/css/style.css" rel="stylesheet" />
-	<link href="{{PublicWWWURL}}/mailslurper/themes/{{.Theme}}/style.css" rel="stylesheet" id="themeStylesheet" />
+	<link href="{{.PublicWWWURL}}/www/mailslurper/themes/{{.Theme}}/bootstrap.css" rel="stylesheet" id="themeBootstrapStylesheet" />
+	<link href="{{.PublicWWWURL}}/www/fontawesome/css/font-awesome.css" rel="stylesheet" />
+	<link href="{{.PublicWWWURL}}/www/lightbox2/css/lightbox.css" rel="stylesheet" />
+	<link href="{{.PublicWWWURL}}/www/bootstrap-dialog/css/bootstrap-dialog.css" rel="stylesheet" />
+	<link href="{{.PublicWWWURL}}/www/bootstrap-daterangepicker/daterangepicker.css" rel="stylesheet" />
+	<link href="{{.PublicWWWURL}}/www/mailslurper/css/style.css" rel="stylesheet" />
+	<link href="{{.PublicWWWURL}}/www/mailslurper/themes/{{.Theme}}/style.css" rel="stylesheet" id="themeStylesheet" />
 	{{template "css" .}}
 </head>
 
@@ -38,23 +40,23 @@
 					<span class="icon-bar"></span>
 					<span class="icon-bar"></span>
 				</button>
-				<a class="navbar-brand mailSlurperLogoLink" href="{{PublicWWWURL}}"><img src="{{PublicWWWURL}}/mailslurper/images/logo.png" alt="MailSlurper" class="mailSlurperLogo" /></a>
+				<a class="navbar-brand mailSlurperLogoLink" href="{{.PublicWWWURL}}"><img src="{{.PublicWWWURL}}/www/mailslurper/images/logo.png" alt="MailSlurper" class="mailSlurperLogo" /></a>
 			</div>
 
 			<div id="navbar" class="collapse navbar-collapse">
 				<ul class="nav navbar-nav">
 					<li>
-						<a href="{{PublicWWWURL}}">
+						<a href="{{.PublicWWWURL}}">
 							<i class="fa fa-home fa-lg"></i>
 						</a>
 					</li>
 					<li>
-						<a href="{{PublicWWWURL}}/savedsearches">
+						<a href="{{.PublicWWWURL}}/savedsearches">
 							<i class="fa fa-filter"></i>
 						</a>
 					</li>
 					<li>
-						<a href="{{PublicWWWURL}}/admin">
+						<a href="{{.PublicWWWURL}}/admin">
 							<i class="fa fa-cog"></i>
 						</a>
 					</li>
@@ -78,35 +80,35 @@
 	<!-- /.container -->
 </body>
 
-<script src="{{PublicWWWURL}}/npo/npo.js"></script>
-<script src="{{PublicWWWURL}}/moment/moment.js"></script>
-<script src="{{PublicWWWURL}}/handlebars/handlebars.js"></script>
-<script src="{{PublicWWWURL}}/mailslurper/templates/helpers/attachmentURL.js"></script>
-<script src="{{PublicWWWURL}}/mailslurper/templates/helpers/autoRefreshSelector.js"></script>
-<script src="{{PublicWWWURL}}/mailslurper/templates/helpers/dateFormatSelector.js"></script>
-<script src="{{PublicWWWURL}}/mailslurper/templates/helpers/formatDateTime.js"></script>
-<script src="{{PublicWWWURL}}/mailslurper/templates/helpers/ifIsImageAttachment.js"></script>
-<script src="{{PublicWWWURL}}/mailslurper/templates/helpers/themeSelector.js"></script>
-<script src="{{PublicWWWURL}}/mailslurper/templates/helpers/pageSelector.js"></script>
-<script src="{{PublicWWWURL}}/mailslurper/templates/helpers/unescape.js"></script>
-<script src="{{PublicWWWURL}}/jquery/jquery.js"></script>
-<script src="{{PublicWWWURL}}/blockui/jquery.blockUI.js"></script>
-<script src="{{PublicWWWURL}}/bootstrap/js/bootstrap.js"></script>
-<script src="{{PublicWWWURL}}/bootstrap-daterangepicker/daterangepicker.js"></script>
-<script src="{{PublicWWWURL}}/bootstrap-dialog/js/bootstrap-dialog.js"></script>
-<script src="{{PublicWWWURL}}/bootstrap-growl/jquery.bootstrap-growl.js"></script>
-<script src="{{PublicWWWURL}}/lightbox2/js/lightbox.js"></script>
+<script src="{{.PublicWWWURL}}/www/npo/npo.js"></script>
+<script src="{{.PublicWWWURL}}/www/moment/moment.js"></script>
+<script src="{{.PublicWWWURL}}/www/handlebars/handlebars.js"></script>
+<script src="{{.PublicWWWURL}}/www/mailslurper/templates/helpers/attachmentURL.js"></script>
+<script src="{{.PublicWWWURL}}/www/mailslurper/templates/helpers/autoRefreshSelector.js"></script>
+<script src="{{.PublicWWWURL}}/www/mailslurper/templates/helpers/dateFormatSelector.js"></script>
+<script src="{{.PublicWWWURL}}/www/mailslurper/templates/helpers/formatDateTime.js"></script>
+<script src="{{.PublicWWWURL}}/www/mailslurper/templates/helpers/ifIsImageAttachment.js"></script>
+<script src="{{.PublicWWWURL}}/www/mailslurper/templates/helpers/themeSelector.js"></script>
+<script src="{{.PublicWWWURL}}/www/mailslurper/templates/helpers/pageSelector.js"></script>
+<script src="{{.PublicWWWURL}}/www/mailslurper/templates/helpers/unescape.js"></script>
+<script src="{{.PublicWWWURL}}/www/jquery/jquery.js"></script>
+<script src="{{.PublicWWWURL}}/www/blockui/jquery.blockUI.js"></script>
+<script src="{{.PublicWWWURL}}/www/bootstrap/js/bootstrap.js"></script>
+<script src="{{.PublicWWWURL}}/www/bootstrap-daterangepicker/daterangepicker.js"></script>
+<script src="{{.PublicWWWURL}}/www/bootstrap-dialog/js/bootstrap-dialog.js"></script>
+<script src="{{.PublicWWWURL}}/www/bootstrap-growl/jquery.bootstrap-growl.js"></script>
+<script src="{{.PublicWWWURL}}/www/lightbox2/js/lightbox.js"></script>
 
-<script src="{{PublicWWWURL}}/mailslurper/js/services/SettingsService.js"></script>
-<script src="{{PublicWWWURL}}/mailslurper/js/services/AuthService.js"></script>
-<script src="{{PublicWWWURL}}/mailslurper/js/services/AlertService.js"></script>
-<script src="{{PublicWWWURL}}/mailslurper/js/services/MailService.js"></script>
-<script src="{{PublicWWWURL}}/mailslurper/js/services/SeedService.js"></script>
-<script src="{{PublicWWWURL}}/mailslurper/js/services/VersionService.js"></script>
-<script src="{{PublicWWWURL}}/mailslurper/js/services/TemplateService.js"></script>
+<script src="{{.PublicWWWURL}}/www/mailslurper/js/services/SettingsService.js"></script>
+<script src="{{.PublicWWWURL}}/www/mailslurper/js/services/AuthService.js"></script>
+<script src="{{.PublicWWWURL}}/www/mailslurper/js/services/AlertService.js"></script>
+<script src="{{.PublicWWWURL}}/www/mailslurper/js/services/MailService.js"></script>
+<script src="{{.PublicWWWURL}}/www/mailslurper/js/services/SeedService.js"></script>
+<script src="{{.PublicWWWURL}}/www/mailslurper/js/services/VersionService.js"></script>
+<script src="{{.PublicWWWURL}}/www/mailslurper/js/services/TemplateService.js"></script>
 
-<script src="{{PublicWWWURL}}/mailslurper/js/widgets/SavedSearchesWidget.js"></script>
-<script src="{{PublicWWWURL}}/mailslurper/js/app.js"></script>
+<script src="{{.PublicWWWURL}}/www/mailslurper/js/widgets/SavedSearchesWidget.js"></script>
+<script src="{{.PublicWWWURL}}/www/mailslurper/js/app.js"></script>
 {{template "js" .}}
 
 </html>

--- a/cmd/mailslurper/www/mailslurper/pages/admin.gohtml
+++ b/cmd/mailslurper/www/mailslurper/pages/admin.gohtml
@@ -14,5 +14,5 @@
 {{end}}
 
 {{define "js"}}
-	<script src="/www/mailslurper/js/controllers/AdminController.js"></script>
+	<script src="{{PublicWWWRoot}}/mailslurper/js/controllers/AdminController.js"></script>
 {{end}}

--- a/cmd/mailslurper/www/mailslurper/pages/admin.gohtml
+++ b/cmd/mailslurper/www/mailslurper/pages/admin.gohtml
@@ -14,5 +14,5 @@
 {{end}}
 
 {{define "js"}}
-	<script src="{{PublicWWWURL}}/mailslurper/js/controllers/AdminController.js"></script>
+	<script src="{{.PublicWWWURL}}/www/mailslurper/js/controllers/AdminController.js"></script>
 {{end}}

--- a/cmd/mailslurper/www/mailslurper/pages/admin.gohtml
+++ b/cmd/mailslurper/www/mailslurper/pages/admin.gohtml
@@ -14,5 +14,5 @@
 {{end}}
 
 {{define "js"}}
-	<script src="{{PublicWWWRoot}}/mailslurper/js/controllers/AdminController.js"></script>
+	<script src="{{PublicWWWURL}}/mailslurper/js/controllers/AdminController.js"></script>
 {{end}}

--- a/cmd/mailslurper/www/mailslurper/pages/index.gohtml
+++ b/cmd/mailslurper/www/mailslurper/pages/index.gohtml
@@ -7,5 +7,5 @@
 {{end}}
 
 {{define "js"}}
-	<script src="/www/mailslurper/js/controllers/HomeController.js"></script>
+	<script src="{{PublicWWWRoot}}/mailslurper/js/controllers/HomeController.js"></script>
 {{end}}

--- a/cmd/mailslurper/www/mailslurper/pages/index.gohtml
+++ b/cmd/mailslurper/www/mailslurper/pages/index.gohtml
@@ -7,5 +7,5 @@
 {{end}}
 
 {{define "js"}}
-	<script src="{{PublicWWWRoot}}/mailslurper/js/controllers/HomeController.js"></script>
+	<script src="{{PublicWWWURL}}/mailslurper/js/controllers/HomeController.js"></script>
 {{end}}

--- a/cmd/mailslurper/www/mailslurper/pages/index.gohtml
+++ b/cmd/mailslurper/www/mailslurper/pages/index.gohtml
@@ -7,5 +7,5 @@
 {{end}}
 
 {{define "js"}}
-	<script src="{{PublicWWWURL}}/mailslurper/js/controllers/HomeController.js"></script>
+	<script src="{{.PublicWWWURL}}/www/mailslurper/js/controllers/HomeController.js"></script>
 {{end}}

--- a/cmd/mailslurper/www/mailslurper/pages/login.gohtml
+++ b/cmd/mailslurper/www/mailslurper/pages/login.gohtml
@@ -1,6 +1,6 @@
 {{define "body"}}
 <p class="logo-container">
-	<img src="{{PublicWWWRoot}}/mailslurper/images/vertical.png" alt="MailSlurper Logo" />
+	<img src="{{PublicWWWURL}}/mailslurper/images/vertical.png" alt="MailSlurper Logo" />
 </p>
 
 {{if .Error}}
@@ -25,5 +25,5 @@
 {{end}}
 
 {{define "js"}}
-	<script src="{{PublicWWWRoot}}/mailslurper/js/controllers/LoginController.js"></script>
+	<script src="{{PublicWWWURL}}/mailslurper/js/controllers/LoginController.js"></script>
 {{end}}

--- a/cmd/mailslurper/www/mailslurper/pages/login.gohtml
+++ b/cmd/mailslurper/www/mailslurper/pages/login.gohtml
@@ -1,6 +1,6 @@
 {{define "body"}}
 <p class="logo-container">
-	<img src="/www/mailslurper/images/vertical.png" alt="MailSlurper Logo" />
+	<img src="{{PublicWWWRoot}}/mailslurper/images/vertical.png" alt="MailSlurper Logo" />
 </p>
 
 {{if .Error}}
@@ -25,5 +25,5 @@
 {{end}}
 
 {{define "js"}}
-	<script src="/www/mailslurper/js/controllers/LoginController.js"></script>
+	<script src="{{PublicWWWRoot}}/mailslurper/js/controllers/LoginController.js"></script>
 {{end}}

--- a/cmd/mailslurper/www/mailslurper/pages/login.gohtml
+++ b/cmd/mailslurper/www/mailslurper/pages/login.gohtml
@@ -1,6 +1,6 @@
 {{define "body"}}
 <p class="logo-container">
-	<img src="{{PublicWWWURL}}/mailslurper/images/vertical.png" alt="MailSlurper Logo" />
+	<img src="{{.PublicWWWURL}}/www/mailslurper/images/vertical.png" alt="MailSlurper Logo" />
 </p>
 
 {{if .Error}}
@@ -25,5 +25,5 @@
 {{end}}
 
 {{define "js"}}
-	<script src="{{PublicWWWURL}}/mailslurper/js/controllers/LoginController.js"></script>
+	<script src="{{.PublicWWWURL}}/www/mailslurper/js/controllers/LoginController.js"></script>
 {{end}}

--- a/cmd/mailslurper/www/mailslurper/pages/manageSavedSearches.gohtml
+++ b/cmd/mailslurper/www/mailslurper/pages/manageSavedSearches.gohtml
@@ -6,5 +6,5 @@
 {{end}}
 
 {{define "js"}}
-	<script src="{{PublicWWWURL}}/mailslurper/js/controllers/ManageSavedSearchesController.js"></script>
+	<script src="{{.PublicWWWURL}}/www/mailslurper/js/controllers/ManageSavedSearchesController.js"></script>
 {{end}}

--- a/cmd/mailslurper/www/mailslurper/pages/manageSavedSearches.gohtml
+++ b/cmd/mailslurper/www/mailslurper/pages/manageSavedSearches.gohtml
@@ -6,5 +6,5 @@
 {{end}}
 
 {{define "js"}}
-	<script src="{{PublicWWWRoot}}/mailslurper/js/controllers/ManageSavedSearchesController.js"></script>
+	<script src="{{PublicWWWURL}}/mailslurper/js/controllers/ManageSavedSearchesController.js"></script>
 {{end}}

--- a/cmd/mailslurper/www/mailslurper/pages/manageSavedSearches.gohtml
+++ b/cmd/mailslurper/www/mailslurper/pages/manageSavedSearches.gohtml
@@ -6,5 +6,5 @@
 {{end}}
 
 {{define "js"}}
-	<script src="/www/mailslurper/js/controllers/ManageSavedSearchesController.js"></script>
+	<script src="{{PublicWWWRoot}}/mailslurper/js/controllers/ManageSavedSearchesController.js"></script>
 {{end}}

--- a/cmd/mailslurper/www/mailslurper/templates/helpers/attachmentURL.js
+++ b/cmd/mailslurper/www/mailslurper/templates/helpers/attachmentURL.js
@@ -4,5 +4,5 @@
 "use strict";
 
 Handlebars.registerHelper("attachmentURL", function (attachment) {
-	return window.SettingsService.getServiceURL(window.SettingsService.retrieveServiceSettings()) + "/mail/" + attachment.mailId + "/attachment/" + attachment.id;
+	return window.SettingsService.getServiceURL() + "/mail/" + attachment.mailId + "/attachment/" + attachment.id;
 });

--- a/cmd/mailslurper/www/www.go
+++ b/cmd/mailslurper/www/www.go
@@ -6,6 +6,8 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/base64"
+	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -100,7 +102,24 @@ func (f *_escFile) Close() error {
 }
 
 func (f *_escFile) Readdir(count int) ([]os.FileInfo, error) {
-	return nil, nil
+	if !f.isDir {
+		return nil, fmt.Errorf(" escFile.Readdir: '%s' is not directory", f.name)
+	}
+
+	fis, ok := _escDirs[f.local]
+	if !ok {
+		return nil, fmt.Errorf(" escFile.Readdir: '%s' is directory, but we have no info about content of this dir, local=%s", f.name, f.local)
+	}
+	limit := count
+	if count <= 0 || limit > len(fis) {
+		limit = len(fis)
+	}
+
+	if len(fis) == 0 && count > 0 {
+		return nil, io.EOF
+	}
+
+	return []os.FileInfo(fis[0:limit]), nil
 }
 
 func (f *_escFile) Stat() (os.FileInfo, error) {
@@ -191,9 +210,10 @@ func FSMustString(useLocal bool, name string) string {
 var _escData = map[string]*_escFile{
 
 	"/www/blockui/jquery.blockUI.js": {
+		name:    "jquery.blockUI.js",
 		local:   "www/blockui/jquery.blockUI.js",
 		size:    19966,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/+x8/3cbt/Hgz9JfMVbU7NIil5SU2A0Z2i913IuvcZ2rlfZ6fr4+cBckEYHAZoEVRcf6
 3+/NANjFLinZl/bup0/7XszFl8FgMN8H0Pjxo2N4DL/8j5pXO1hInV///ApKWa+Ewo6/88oIreAiezrJ
@@ -310,9 +330,10 @@ Av5NAAA=
 	},
 
 	"/www/bootstrap-daterangepicker/daterangepicker.css": {
+		name:    "daterangepicker.css",
 		local:   "www/bootstrap-daterangepicker/daterangepicker.css",
 		size:    6576,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/9xZb2/bthN+n09xQFC0DSpZduL8Ud788uuGocAGFFvfD7R4sojQpEBSsdNi332gSNqS
 TClO32wrthaSeDw+fO6549GdXVycXcADaPPMUVeIBkqpoNEIW2Yq+L+URhtFarhMd2cX8D/SmEqqHH4i
@@ -343,9 +364,10 @@ bsZDjmzPj/RP178DAAD//7/X0tKwGQAA
 	},
 
 	"/www/bootstrap-daterangepicker/daterangepicker.js": {
+		name:    "daterangepicker.js",
 		local:   "www/bootstrap-daterangepicker/daterangepicker.js",
 		size:    56716,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/+y9bXcbN5Io/N2/oszHj5uMKFLSJJkzkilfj529yTnRJHed3RyvVjcH7AZFxE2A0w2K
 4sT67/fgrRvdeOkmJWdzdicfYooEqgqFQqFQVShMv/ji2Rfwv+5wURJGz+FscjL5UnyDNnzJinN4hyj8
@@ -516,9 +538,10 @@ UfH0QbT+fwEAAP//EoaXzYzdAAA=
 	},
 
 	"/www/bootstrap-dialog/css/bootstrap-dialog.css": {
+		name:    "bootstrap-dialog.css",
 		local:   "www/bootstrap-dialog/css/bootstrap-dialog.css",
 		size:    2429,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/5xU0W7bOgx9z1cQuLhAbwAlTp1cNB4GDBj2sM+gJcoRIouGpKxLh/77YMXtmjZ2lPnF
 EEmdc0iRXNTMMUSPnVAGLTfwawawnMNwiseOAsyXyTifQf/N4btkB+hMi9Gwe7F+5c6QAu25Bc0uCnyk
@@ -535,9 +558,10 @@ CQAA
 	},
 
 	"/www/bootstrap-dialog/js/bootstrap-dialog.js": {
+		name:    "bootstrap-dialog.js",
 		local:   "www/bootstrap-dialog/js/bootstrap-dialog.js",
 		size:    44135,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/+x9f3fbNrLo//4UiI9PKKUylR99+96Rq3Qd22n9Gtu9sdts1/XJgUhIQkyBKgHZVrP+
 7vfgFwmSAEjKTrP33PUfiU3MDGYGA2AwGADDZ2CWpBOYgBhNMUHg2XBra/gMjDv+bIFn4AReI7CiCKRT
@@ -669,9 +693,10 @@ MCOYzBxORWn9vzAvt3kEj+NWVT2uXcE+yHtdy2BAa3fD+lZVPuQsKtf3NKvvEJIZyr6G9mJZ81+pPPls
 	},
 
 	"/www/bootstrap-growl/jquery.bootstrap-growl.js": {
+		name:    "jquery.bootstrap-growl.js",
 		local:   "www/bootstrap-growl/jquery.bootstrap-growl.js",
 		size:    1959,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/2xVz2/rNgy+56/guG6QUcfPK/YOdeoOww7bOwzDTjssQ6HadKI9xTIkuU1W5H8f9MOO
 EzuXQBL5kR/5kWZN31ZWqJYl8LECeOMa7jarFcAdlPDvnz3pUzhmr0pZYzXvftXqXUIJo+uBjOE7SkF1
@@ -691,9 +716,10 @@ pwcAAA==
 	},
 
 	"/www/bootstrap/css/bootstrap-theme.css": {
+		name:    "bootstrap-theme.css",
 		local:   "www/bootstrap/css/bootstrap-theme.css",
 		size:    26132,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/+xdbW/buhX+nl/BoSiaFDYty1Zsp2gxrLsYCrT7sHXAgGEfKJFyhGtLgkQnLi7y3weR
 km1KFEWR9F0K3Pi+1JT0PIfk0cOXc5jO3v/pBrwHf8kyWtIC5eBpARfwHtw+Upo/zGZbQsPmGoyy/V11
@@ -747,9 +773,10 @@ JzAqS7hHOXg/u/lfAAAA//92WaQYFGYAAA==
 	},
 
 	"/www/bootstrap/css/bootstrap-theme.css.map": {
+		name:    "bootstrap-theme.css.map",
 		local:   "www/bootstrap/css/bootstrap-theme.css.map",
 		size:    47706,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/+xdCXPbRrL+K/PksiPFIHiJOshNihRJydzI19p5K+06VR4AQxIRCCAAqMMp//dXc+Gc
 AQY81s6rlTZrctDzdfd0T/ec0J8H9ygIbc896He1g9BbByYKD/r/PjA8LwqjAPqNaIlWSDfD8EA7cFAY
@@ -874,9 +901,10 @@ O6RVQxTFN4NmU/6GJv7ipvRE65Obu4NO3W/jsJT/w7yfDvhdhoPfvv5fAAAA//96ZDGDWroAAA==
 	},
 
 	"/www/bootstrap/css/bootstrap.css": {
+		name:    "bootstrap.css",
 		local:   "www/bootstrap/css/bootstrap.css",
 		size:    146082,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/+y9a4/kOJIg+D1+hToLhcqscinl8ld4JCpv5noXOw1Mz4fbPmCB6roDXaK71CmX1JI8
 HtUb+9sPEkWJDzOS8vDMmlt0xUxnhGhmNJoZjcaX8eOPf7jzfvT+z7Jsm7Ymlfe4ClbB1nuftm318PHj
@@ -1233,9 +1261,10 @@ P979fwEAAP//RKe1DKI6AgA=
 	},
 
 	"/www/bootstrap/css/bootstrap.css.map": {
+		name:    "bootstrap.css.map",
 		local:   "www/bootstrap/css/bootstrap.css.map",
 		size:    389227,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/9T9C5PbOtImCP8VjTu+6O5XpRJvkihXzPuNSKpUKlcdH/sct9un3btBSSySEm/iRbeZ
 /u8bQAIkSICUqt+d3Vh3x7HMJ59EIpEAkiAI/s8PByfN/Dj68FG9+5DFRbp2sg8f//FhFcd5lqd2cr/O
@@ -2477,9 +2506,10 @@ H6tATrfkpC6vIqXXGIPXph1fLUSe+5/hCnRO7RDR6tHfbv+/AAAA//+9aVk8a/AFAA==
 	},
 
 	"/www/bootstrap/fonts/glyphicons-halflings-regular.eot": {
+		name:    "glyphicons-halflings-regular.eot",
 		local:   "www/bootstrap/fonts/glyphicons-halflings-regular.eot",
 		size:    20127,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/4ywVVDeYZPt+8fd3V/c4cU9uLu7u7sECO7u7u4eHIK7OwSCBIK7kwCn5ptTU7v23Oxf
 1XPxrF7dvaoLlQBAVBEAIAFIABr4L2CA/wYCSIIAAGhAQeX/FyCB/6n8N7SYgUzA/4IOkAYUAF1ABZAB
@@ -2820,9 +2850,10 @@ gSlyhSHVCuIoCgPSBGmCYAEAAP//WMexnJ9OAAA=
 	},
 
 	"/www/bootstrap/fonts/glyphicons-halflings-regular.svg": {
+		name:    "glyphicons-halflings-regular.svg",
 		local:   "www/bootstrap/fonts/glyphicons-halflings-regular.svg",
 		size:    108738,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/+y9bY8kyZEm9n1/hWkE6IMEr3Ezf9eSe4BuDwcBKumAO52gT8IcOWQSiCUvOHG5q/r1
 gj1mHplVXRlZXdUz3bMiOOyMivDw8Bdzd3t97Df/5l/+aaHzj3/96U9/+fNvv+OH+B39tP3w59//sPzl
@@ -3264,9 +3295,10 @@ qAEA
 	},
 
 	"/www/bootstrap/fonts/glyphicons-halflings-regular.ttf": {
+		name:    "glyphicons-halflings-regular.ttf",
 		local:   "www/bootstrap/fonts/glyphicons-halflings-regular.ttf",
 		size:    45404,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/+z9e3wb1ZU4gN8zc0czGkkzkjUjWbYleyRbsmzZTiRLSuJETkJIQuI8ICEkBEJCBkIC
 JCYkIZTwDm/ShhYcwnvDKw2EmEdpKdnSTUvRlm1LqcsWCq2dBb7ZbstSGgo41vj3uXckWVachN3+9vP7
@@ -3671,9 +3703,10 @@ AwAA//+aFzycXLEAAA==
 	},
 
 	"/www/bootstrap/fonts/glyphicons-halflings-regular.woff": {
+		name:    "glyphicons-halflings-regular.woff",
 		local:   "www/bootstrap/fonts/glyphicons-halflings-regular.woff",
 		size:    23424,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/2S0Y3Ad7vP/fcLGaWw7jRvbTmOjsW3bVmPbthubJ1bj5MR2zj2f3/d+9r9mXvOaa/bJ
 vndm10NRUhIAAQAAALqBANT/3Kj3v///+yQl1RQAAAgtAABA+B929OlbUuISkgAAhCsAACABAACkEOIA
@@ -4066,9 +4099,10 @@ XmeJ/Rh6DP1ZZVv3n7j8Fyz+g9nTiFO5v4X3ds9a6htr3GsV07D1a7rC55mQA+lLhjvCx6gnuef/x7ge
 	},
 
 	"/www/bootstrap/fonts/glyphicons-halflings-regular.woff2": {
+		name:    "glyphicons-halflings-regular.woff2",
 		local:   "www/bootstrap/fonts/glyphicons-halflings-regular.woff2",
 		size:    18028,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/wAVQOq/d09GMgABAAAAAEZsAA8AAAAAsVwAAEYJAAECTQAAAAAAAAAAAAAAAAAAAAAA
 AAAAP0ZGVE0cGiAGYACMcggEEQgKgqkkgeVlATYCJAOGdAuEMAAEIAWHIgeVUT93ZWJmBhtljDXsmI+A
@@ -4376,9 +4410,10 @@ AA==
 	},
 
 	"/www/bootstrap/js/bootstrap.js": {
+		name:    "bootstrap.js",
 		local:   "www/bootstrap/js/bootstrap.js",
 		size:    68954,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/+y9a3fcxpEw/J2/oqlwBcAcYih7s0kmHvFQIv2G+8qiHpFOdh+GSTCDJgcWBkAADCnG
 ZH77c7r6VtVoYIa0Iu+eI32wOeju6upbdd17/NX2FvuKvSrLtmnrpGI338TfxP/BwkXbVpPx+Jq3M10W
@@ -4619,9 +4654,10 @@ Xn8R2Oe9jiL/LwAA///1TydqWg0BAA==
 	},
 
 	"/www/fontawesome/css/font-awesome.css": {
+		name:    "font-awesome.css",
 		local:   "www/fontawesome/css/font-awesome.css",
 		size:    28747,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/9R8Xa/kNnL2/fwKvTb29YxxdOZQ3ac/TrDZdRIsssBudoG1gVzkhqJKLbopUiap7tMO
 5r8HUn+opO4qTQDf5Fx43OJTFD+KxWLVQ33+/v99SL5Pkj85G5MfjhBcDcnyefH8kuSn5I+FPMBO2uKU
@@ -4720,9 +4756,10 @@ V9gzxHuuXJzsUTl9nSJDNOiDlogs9gA6cho54AaT5I90dj1bjG706ZZ2ei6c5v8JAAD//88/STFLcAAA
 	},
 
 	"/www/fontawesome/css/font-awesome.css.map": {
+		name:    "font-awesome.css.map",
 		local:   "www/fontawesome/css/font-awesome.css.map",
 		size:    21778,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/7xcW3PiOpd9719xKq9wDhdDwMdPknAISQhJJ+lcpqamCCHcjG1sYwxT89+nZEhnWVl8
 X2qqzvRTYxa6bO299tqSnP/+cZKOo3gW+Cd//2GVf5wsh2E48yfxyd9/nDj7f0J0RflBPCjHFfeq/CjE
@@ -4803,9 +4840,10 @@ x8Fy/JdG/vifH/8bAAD//8sQGW0SVQAA
 	},
 
 	"/www/fontawesome/fonts/FontAwesome.otf": {
+		name:    "FontAwesome.otf",
 		local:   "www/fontawesome/fonts/FontAwesome.otf",
 		size:    93888,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/8z7e3hTVdY4jq80OSfp2UlaIIE2yUkKooggtE1SWkRFuSqCgBEEhEPaJk1omoTkpKWl
 9xvQlkLblFKgUKAocqmiDI54Y7yiqKNSZ9TxdbyM43hvHXCn3Sn8npO0UHzn8/7e5/N8/vg2z85ee+21
@@ -6102,9 +6140,10 @@ qwjobFby/wQAAP//ylPFc8BuAQA=
 	},
 
 	"/www/fontawesome/fonts/fontawesome-webfont.eot": {
+		name:    "fontawesome-webfont.eot",
 		local:   "www/fontawesome/fonts/fontawesome-webfont.eot",
 		size:    60767,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/3TOU3AdgJfH8Rvb9o3Z2Lyxbdu209jmje00DRvbaBrbttUkTXZmZx929j/7eTlP5zs/
 4ysAwPcSAIAEQAKgAf8bBCAZAgCABiioAP4PiP+5kCrFuID/gAuQAjgDnAAeAFGAN8AS4A5wBjgCLAEA
@@ -7123,9 +7162,10 @@ Q6r85rAfNM4JE6CSrAAAAAAAAAAAAQAA//+qgi3tX+0AAA==
 	},
 
 	"/www/fontawesome/fonts/fontawesome-webfont.svg": {
+		name:    "fontawesome-webfont.svg",
 		local:   "www/fontawesome/fonts/fontawesome-webfont.svg",
 		size:    313398,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/+y9bY8kyZEm9n1/hWkE6Jv3uJm/H8k9QLeHgwC1dMCtTtDH5kyTSSh2uMHxzV31rxfs
 MYvIzKrMqKqe7h5SWpDTmZXh4e9ubq+P/fY//ts/LXT++Jef//Tnn373Hb+L39HP88NPP35Y/vzTx999
@@ -8660,9 +8700,10 @@ pKYV29noF5el2ykAAgAA//+p7oVjNsgEAA==
 	},
 
 	"/www/fontawesome/fonts/fontawesome-webfont.ttf": {
+		name:    "fontawesome-webfont.ttf",
 		local:   "www/fontawesome/fonts/fontawesome-webfont.ttf",
 		size:    122092,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/8z9CXwcxbUoDtep3mbrnunpnp7RaDSatUeyzMieVba1jOXdko3BBoNthGwwNgaDARuD
 w9KAA9g4LAYch4REQCA4N8klC3kJwdzJBjcL3Cy+JCHLFbkhyQtLbMLjBVvT+n5VPTMayTZk+e77/WWr
@@ -9871,9 +9912,10 @@ GBjEwCAGBjEwiIFBDAzhi2UgMhAZCGiAZeXDw8Nf/vNfNj48/C8AAP//MvCuEezcAQA=
 	},
 
 	"/www/fontawesome/fonts/fontawesome-webfont.woff": {
+		name:    "fontawesome-webfont.woff",
 		local:   "www/fontawesome/fonts/fontawesome-webfont.woff",
 		size:    71508,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/2ySU2wlbr+Fd23b7ZTTqW1jatu2212bU9u2bdu2bds4+X/X502erDx5s25Wfq5yYmIA
 EAAAAIKlDED8Lzcv/+f/zxMTU5YBAEBEAAAA/n/YgM67iIuIigEAIPoAAIDwf1CCMssp0TMBACB+AACA
@@ -11072,9 +11114,10 @@ AVTBNW0AAAEAAP//PWafm1QXAQA=
 	},
 
 	"/www/fontawesome/fonts/fontawesome-webfont.woff2": {
+		name:    "fontawesome-webfont.woff2",
 		local:   "www/fontawesome/fonts/fontawesome-webfont.woff2",
 		size:    56780,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/wASQO2/d09GMgABAAAAAN3MAA4AAAAB3OQAAN1sAAQAxQAAAAAAAAAAAAAAAAAAAAAA
 AAAAP0ZGVE0cGh4GYACFQhEICobjZIW0WgE2AiQDkSoLiFwABCAFhwAHqx4/d2ViZgZbBYBxhnF7IVHR
@@ -12027,9 +12070,10 @@ j4xMTU1NXSk/SWQSzTEMsXkPen8XRYf7fwEAAP//wrCtx8zdAAA=
 	},
 
 	"/www/handlebars/handlebars.amd.js": {
+		name:    "handlebars.amd.js",
 		local:   "www/handlebars/handlebars.amd.js",
 		size:    143845,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/+y9e3/bOLIo+L8/RcWnN5ISWhKpp+Xx5LgT98TnJE7Wdk/fWdmdpiXIYocidUjKjm7i
 +ez7Q+HBAkg9HCeZ2fvbecQiCBQKhUK9UAAbz57s7MDUj8Yhu/aTFG5b9Wa9tbPzMp4vk+BmmkH1ZQ28
@@ -12574,9 +12618,10 @@ BNj+Ko37Gne2bztAW+rZxXvXJ75JdjTkL04ql95mqZuWCrzNm7avGXNJjDeQwU9WjjKHndknR5xGWM0m
 	},
 
 	"/www/handlebars/handlebars.js": {
+		name:    "handlebars.js",
 		local:   "www/handlebars/handlebars.js",
 		size:    143356,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/+y963bbOLIw+jt+Ctg7K5ISRrKoq+Xx9HEn7m7PJHaO7XR/87m9E0qELHYoUpuk7GgS
 v/tZKNwKICjLufTM7HWypscirgWgUFUoFKpaT7e3tsgsSMKYjoMsJzed5m6zs7X1Il2ssuh6VpD6iwbx
@@ -13127,9 +13172,10 @@ FWf/HQAA///MoGFA/C8CAA==
 	},
 
 	"/www/handlebars/handlebars.runtime.amd.js": {
+		name:    "handlebars.runtime.amd.js",
 		local:   "www/handlebars/handlebars.runtime.amd.js",
 		size:    22956,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/9R8/XPbOLLg7/orOtmrUEpoys7s7VVJ0eQcRxnr1pZcsjK5Oa8rA5GQiYQiuABoW5fx
 //4KXyRAUo5nZvfVe1NTsYiPRqO70egvcvjyWa8HKcqTDK8R43D7Q3QY/dDrndBix8hNKqB/MoDXh0dH
@@ -13247,9 +13293,10 @@ g6asWQAA
 	},
 
 	"/www/handlebars/handlebars.runtime.js": {
+		name:    "handlebars.runtime.js",
 		local:   "www/handlebars/handlebars.runtime.js",
 		size:    25345,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/9x8f3PbOLLg39an6PhthVLCUHYyO1sljTbnOMpEbxzZJSvJzfm5PBAJWYgpgA8Abesy
 /u5X+EWCP6Q4M/O2as+Vikig0Wh0NxqNRoP9Z086HVghmqR4gbiA21fRQfSq0zlm2YaT65WE7nEPXh4c
@@ -13376,9 +13423,10 @@ AP//25poYAFjAAA=
 	},
 
 	"/www/jquery/jquery.js": {
+		name:    "jquery.js",
 		local:   "www/jquery/jquery.js",
 		size:    247597,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/8y9e3fbRpI4+jf5KVpwVgYlPiTZztiUaV3Hdma1N3Y8kbPZeyVm0wSaZNsgwHSDkjih
 5rPf01XVD4CgbM9k9/7mnIlFoNGP6urqetfgYK/NDtjHv62EWrP/4Nf8IlFyWbIf5ERxtWbXJ/3j/mPT
@@ -14611,9 +14659,10 @@ psogYDsMu23CSMcu5tKPGDZLMg29m8HgqPf/BwAA//+WFHq3LccDAA==
 	},
 
 	"/www/lightbox2/css/lightbox.css": {
+		name:    "lightbox.css",
 		local:   "www/lightbox2/css/lightbox.css",
 		size:    3898,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/+RXTW/jNhC9+1cQWwS7G6xk2XGyMYMUULKLdoEWSYMeeqUkWiJCcQSKsp0U/e8FKVLR
 d9q0PTWHwCJHw5l5M+9Ry1N0LykHkiCWk5SW6HS5iCB5wmSnqES/LxCKQSgqFEaV5B98f1kbLmMOJfUL
@@ -14636,9 +14685,10 @@ WW0omvMGCv7Wgf88+LL5/Dq5rV8jt/U8ua1nyG1dTiDRYreRe8G/S3h/BgAA///Sce/SOg8AAA==
 	},
 
 	"/www/lightbox2/images/close.png": {
+		name:    "close.png",
 		local:   "www/lightbox2/images/close.png",
 		size:    280,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/+oM8HPn5ZLiYmBg4PX0cAliYGCQBmEOZgYGhl1cLOkMDAw2AT4hrv///2dgYPj7929T
 U1NDQwMDDHh7e0MYq8Bg165dXl5eHh4eDAwMu3fv3rlz5////z/nHZZhYGAQLgnyC2bw+rd6NYOY9zQe
@@ -14649,9 +14699,10 @@ i3yzpe/Nhq0X9xydmOGs87l9285wlZ3Td00q+tKm0m+59WH/goXnGlWUOj2UJnVYd7xQUOCoMK92SJLn
 	},
 
 	"/www/lightbox2/images/loading.gif": {
+		name:    "loading.gif",
 		local:   "www/lightbox2/images/loading.gif",
 		size:    8476,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/4S5eVRT977+v6fsKdNOCBBISHYmMjAkIFXqtd6QBA2IGoZa9PTYgNhitT1xtg41gSBh
 UBmigloFBETrgHXCgRomFRUFQaXWanCqtepBq9bL6fBbntv2tL911/ruP/f+a7/W+3k+7+f5TEyaEP9m
@@ -14788,9 +14839,10 @@ EagI59Gvpi9+cC5oRkSzIzXcCRzAG8mocpMr9XCxUWOlgcQrn9NKGwEB//X/BQAA//9hTAgpHCEAAA==
 	},
 
 	"/www/lightbox2/images/next.png": {
+		name:    "next.png",
 		local:   "www/lightbox2/images/next.png",
 		size:    1350,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/wBGBbn6iVBORw0KGgoAAAANSUhEUgAAADIAAAAtCAYAAADsvzj/AAAFDUlEQVR4Ac2Z
 S0xcVRjHvTN3hisw0GIRZ3AeLWHQWqdVsRqgA86AUmpqoy20Whd2YYhprJq45BVAF7yJkQQTluDGiEhB
@@ -14819,9 +14871,10 @@ XK5Ic3PzF0NDQ1ODg4NT+P0rCFbQM3qu4MRWLsIfX7PB0yAEngPP089TwA8yBMFWKmJ+qZBGj7FecJzw
 	},
 
 	"/www/lightbox2/images/prev.png": {
+		name:    "prev.png",
 		local:   "www/lightbox2/images/prev.png",
 		size:    1360,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/wBQBa/6iVBORw0KGgoAAAANSUhEUgAAADIAAAAtCAYAAADsvzj/AAAFF0lEQVR4Ac2Z
 W0xcVRSGPTNnhlPKcCsUAeeChkEVxhutDQwzMANaqamNWgpaH+yDIaZp1cRHbgH0gTsxkmDCI/hiRAqg
@@ -14851,9 +14904,10 @@ IWSf3VAFAAA=
 	},
 
 	"/www/lightbox2/js/lightbox-plus-jquery.js": {
+		name:    "lightbox-plus-jquery.js",
 		local:   "www/lightbox2/js/lightbox-plus-jquery.js",
 		size:    262964,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/8y9e3fbRpI4+jf5KVpwVgYlPiTZztiUaV3Hdma1N3Y8kbPZeyVm0wSaZNsgwHSDkjih
 5rPf01XVD4CgbM9k9/7mnIlFoNGP6urqetfgYK/NDtjHv62EWrP/4Nf8IlFyWbIf5ERxtWbXJ/3j/mPT
@@ -16152,9 +16206,10 @@ AA==
 	},
 
 	"/www/lightbox2/js/lightbox.js": {
+		name:    "lightbox.js",
 		local:   "www/lightbox2/js/lightbox.js",
 		size:    15366,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/8w7f1cbOZL/8ylqWCbdHkwbsjc7exBnzwFmh1smySbs5t3Ly92Tu2W3oC31Smob78B3
 v6cfrZb6hyE3c/eOP3i0VKoqVZWqSqVi8t03e/AdXJNlLufsHtYvkz8mJ2povoVrdodFDhc5ukN8D75T
@@ -16231,9 +16286,10 @@ vAY8AAA=
 	},
 
 	"/www/mailslurper/css/login.css": {
+		name:    "login.css",
 		local:   "www/mailslurper/css/login.css",
 		size:    328,
-		modtime: 1527568074,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/2TOzWryQBSH8bVzFf+NGyEa9RVekpWIC6EthbYXMM4cJwOTOWHmxCYU772QfkG7//Hw
 rBbqwN2YvGsEm3K9LTbl+j/2Vrd4TJQDjUvsQ8AkMhJlSley6iUT+AJpfEbmPhmCYUvwGY6vlCJZnEdI
@@ -16244,9 +16300,10 @@ zYQGKXTwLlYwFIVS/QWLM4twW2Gz64Za3dSfpm/dR3coXr2VpsK/cv4tp8LwC2x38/rnpPzcuL0HAAD/
 	},
 
 	"/www/mailslurper/css/style.css": {
+		name:    "style.css",
 		local:   "www/mailslurper/css/style.css",
 		size:    2278,
-		modtime: 1527568088,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/4yV8WvrNhDHf47+ihtlsIUptZ24TRz2Q/fooNCOQff+ANmSbVFFMpLSJHu8/33IdnJK
 mj5GKZGtj+7O97073U7JF9MdrGxaD1mSzmmWpEt44GwDf1vhlDjM4EEp6AkHVjhh3wUnX50AU4NvpQNn
@@ -16267,9 +16324,10 @@ JnU/7MJQ71r2i+lYJf3h9zRJfg0J+y8AAP//w3WNK+YIAAA=
 	},
 
 	"/www/mailslurper/images/favicon.ico": {
+		name:    "favicon.ico",
 		local:   "www/mailslurper/images/favicon.ico",
 		size:    21449,
-		modtime: 1523580397,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/+x7CVhTR9f/JAGigsBIFVTEBQWLrIqIVcAqoojLFZoGxCDF5YIrFEMRQRIVhaKvC4IK
 blUBAQ0FrFo2ry0UK6uAYqFAil9cAGWHACH5P9Hh3/vlZfNt+25fzsPvublzZ845d2buzJnfDABQgCJQ
@@ -16370,9 +16428,10 @@ AA==
 	},
 
 	"/www/mailslurper/images/logo.png": {
+		name:    "logo.png",
 		local:   "www/mailslurper/images/logo.png",
 		size:    8160,
-		modtime: 1523308689,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/+x5+z+UW/j2mhmGMiLEjIamMbErpxlilMaI0SPKpm2nkkMzkk00dCBiJjuMw5gZ2SUV
 RUe76CTKRjk8M+VUOrA7qJlJKpVBOYX384z9/f4L7/vD+4PPx7Oee13rvq91Xfda83kEv25arzvfdD4A
@@ -16497,9 +16556,10 @@ AAD//3ODLFXgHwAA
 	},
 
 	"/www/mailslurper/images/vertical.png": {
+		name:    "vertical.png",
 		local:   "www/mailslurper/images/vertical.png",
 		size:    15036,
-		modtime: 1523308689,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/+y551eT3RM2eocAAQQEAR8lQYgoXYoioTcFBIHQUZGiPIj0gAakJjQRlCYgSu+ISFN6
 jYA0EZAinYD0GnqAkOSs+Ly/D+dPOGe9H7KSlb1n9jXXvmYykzvSyFCHjYWXBQAANt07t00AgF4eAEDf
@@ -16737,61 +16797,64 @@ vDoAAA==
 	},
 
 	"/www/mailslurper/js/app.js": {
+		name:    "app.js",
 		local:   "www/mailslurper/js/app.js",
-		size:    1251,
-		modtime: 1527311021,
+		size:    1239,
+		modtime: 1542257903,
 		compressed: `
-H4sIAAAAAAAC/5RTX0/bMBB/Tj7F4fGQaiwF9jIN9aFCPFQq20TgAxjn4li4vunslFVTvvtkN4GS0Ul7
-sSPb97v7/cl8Dtf0c8dGtwEuzy8+f7o8v/gCy1pu4Aejt7grYWktpBceGD3yFut8PocHj0ANhNZ48NSx
-QlBUIxgPmrbIDmt43EFoEW5X92CNQucxVoZWBlDSwSNCQ52rwbj0br26vvlW3UBjLJZ5flrUpLoNujAr
-GWW9K5rOqWDIQTGD33lmGihOno2r6bmsMATjtK+Qt0Zh6ff7eHzzy/iwcmtS0laBGItZgsiOlGsM1VuE
-YpZnWVaGFt3BHJM2e8yjqD52nuJOIa4SAmPo2MHkMt31/zNJ1GhyVcou1gajZCytVIsbhJPFAoQYy95o
-u+xCO1II9IQuqelXLiop9YuWB8wt7cFhAWJuSRsn9ryyPn9ZByJKBtUeMEHmiY5Lizz6USIzcSHuW2SE
-Z+lBOkhnoPcER9HAj4ShQkwJU+Q82Rg7hg0xgnEN8SaNWopB+veaWtK36H0ki8xnIFLHoaKPWw9oPaa5
-t5KnxsECjmSCMbDB7UHOrt5CPNytj1e/5vThbv1OlPIsOy3EB0v6exfWxj2JWUmuEMoa9STOYPJHvZI/
-sNySpi4Ur+Mk2/4K4EsGjkSAujBkoB8A/mF8JqP677psSevoMnXhKwj4GI9nA27Ej2ueZ32ePv4EAAD/
-//uMJenjBAAA
+H4sIAAAAAAAC/5RTwW7bOhA8S1+x4ctBQvLkJL0UDXwwghwMOG1RJR/AUGuKCM0NlpRTo/C/F6Qlx1Hj
+Br2IBrk7szOznkzghp43bHQb4Ori8tP/VxeXn2HWyBV8Z/QWNxXMrIVU4YHRI6+xyScTePAItITQGg+e
+OlYIihoE40HTGtlhA48bCC3C3fwerFHoPMbO0MoASjp4RFhS5xowLtUt5je3X+tbWBqLVZ6fFg2pboUu
+lBWjbDbFsnMqGHJQlPArz9aSQT4/P/xYwBRejGvopaoxBOO0r5HXRmGlMcxSSVFe51memSUUJ0dq/e4c
+rm9/Gh/mbkFK2joQY1Em2uw4Vf0WoSjzLMuq0KI7mH1Es8M8iuoj8xh3DHGdEBhDxw5Gj+lt+y+TRI9G
+T5XsYm8wSsbWWrW4QjiZTkGIoe2Nt7MutIOEQE/okpt+7qKTUu+9PFBuaQcO0yHVMxATS9o4sROYbfP9
+t1ekZFDtgSRkHhk6s8hDMBUyExfivkVGeJEepIN0B3qndHAP/KAcasS0noqcJxt3lmFFjGDckniVZq5E
+n8F7pJb0HXofVSPzOYjE2Hds47EFtB7T3HGp+xk+Wux6XxaXO8+y00L8Z0l/68LCuCdRVuQKoaxRT+Ic
+Rn+e11EPkrKkqQvFK38y+Y+92Uf3UXLUhT66bY/0l7wyGU17NxxLWsdwqAtfQMBZvC573Igfv3mebfP0
+43cAAAD//1F/O+PXBAAA
 `,
 	},
 
 	"/www/mailslurper/js/controllers/AdminController.js": {
+		name:    "AdminController.js",
 		local:   "www/mailslurper/js/controllers/AdminController.js",
-		size:    5920,
-		modtime: 1527568108,
+		size:    5935,
+		modtime: 1542257793,
 		compressed: `
-H4sIAAAAAAAC/9RYW2/bNhR+ln7FqbYHufWUtnsZHBiDm6ZdgF6CON0wFMVAS8cWF4o0SMpGOvi/D6JI
-ibIt28k6YMtDIlHnznP5Ts7O4EIs7yVd5BpePn/x4w8vn7/4CSYZKeBaomJ4n8CEMTAUCiQqlCvMwrMz
-+KQQxBx0ThUoUcoUIRUZAlWwECuUHDOY3YPOEd5f3QKjKXKFFafOiYaUcJghzEXJM6Dc0L27urj8ML2E
-OWWYhGE8L3mqqeAQD+CvMIhKhaC0pKmOzsMwaD6nOaZ3v6JUVPCaNFgRaUx7TyibslIuUVoCGEMUnVuS
-tJQSue6lCoNgTXkm1ok9n6Jc0RSTBerqsaGPB2EQBInOkXtmZ0ST2p4g6LWmIkpW9avReECnPXkjRfGW
-6rycxar++Onm3eCQ9uCQp3ssCOgc4v1mUGUPPrIMZbzfr2F/aAeNTcH3cfTdvSjdl2iQ5LpgPSIH5x6X
-lb7F2K/T57WevkelyAKjQSKxECu8YESpOMppliGPHMfG/NnUr5v6llOi09wLNErpfPLCNil13sbsEyel
-zoWkXzEzDE0U9pAvhBbvxILy2Jqx6eTFhKHUjhalFNJItCaeh4a8Mc+kqtaUL1SVN2+ELLwiUfYTjGt7
-MqKxIiF6BFWw2ncQy0reSCHDVGMWDZIVYfFgWLGRUosbnEtU+QismUsiFV5xHVdyPIJeQfDieS1N51hg
-rd889nGEQbAxCStRl5I3zmyHgHKqKWH0K1rPK8kzzW/MxUeDRPA4ShlN76IhdLoOCP7K0V1UBPHgHOps
-sDKmZIUuvscl+dROVBgE3Q62bT4TJJtkBeXXsuR4i8WSEe1csa5zXMO1FAVV6GWmRCXYCocg8U9Mtc05
-ez9OkMukSk0ckUZRZLJ9p6lpy9YkMNkxDcbwC+EZwxmRKklFsaQMW0ZbWtZya2OT6lbrgSJrOSun2ty3
-ZbrpD2Ab+n8vdm0yPCB807YM/1OR201/I+mVEFppSZavKWFikaSCz6ksYqOlqBvrCKKJRLgXJajSPqyp
-ykELWFbZAoJlgAWhTP0c1XVPNav4fpvcfLj68NYe3i9xBNsab3+/vvzD0hmylDA2I+ndCDpXWDLt9+bu
-iemAxpaLCrqMTccx7zeEL3rbjpuR+9rxjIn0Lo6qcqB8kSRJNPBH6hPLM0XMHMuKMFq12WtnSGxM+GiU
-q2FroDc5+ydBdJujRFgTBYSDOYM11blBWM4TdwFGRdIMO5sezejruGmmqlWVIUON1cmVxkJ5KMQ31wrd
-rgAp1moynxtDWo/2qVmgmeUXouTaRzqOZVc0qqXgCj2xlVM8Q9ntnd0IO7akcNqaiFT35k0Pd5d9d1Dy
-OgF8fpWLtdE+LdMUlbLAI94ek524eAI2nr+HavuR+ONkENJJitOTEJZSzBgWFRCpehxUQYa0inLU8dI9
-N/4e8fZxvp7oaevnw0rNVEbjJa2qw6uvTYPn7K+ejtuFCfvA2l5U5y8s7qszWWkhW5lO0t61xW+YjjCp
-gdiTsQP2t9X7NohlIiXark9nZrBFnZF1FM2qukTiqBmIiqwwexL9jwH48f7Ttp3mqqt9Bsawi63qGauF
-Juyy4Ru1Isww9MWPwH+zOWfxqw/26hWq+tXjgbuSxhKXG0NotwSrZr8jTfrtrBpNmrWHwy5N483O0e4C
-0kjzTv3FopvUe0LiAfr+qPT19d35djDTI3gGPgs8g6iGRbEa1HeXRU752dNv+BMG8BQuBFdalqkWsnr/
-dj9nobn/3Qw+9z5Mm40ttB3ODXkYQ08ns/97qcniHiKJWlJcOYDeNtOBVe8XBYzh8xd77re35r9AdjtI
-CGPx5zAI+jayof+t1RkGX6rGdaBvHW8sdYrugY8L1NeeL1s46QhC2oqC+1rDnIcisqNobGuGHb26Zk9u
-2Xeq35fTCcrrbcoWvW3dcbcdOKJ/Ahsf0TAt5z6weQLQPGX3ewxeOgktbQ7YuTUdm0XzcDk83NQTDN2E
-p1faxjSKvwMAAP//L6gfNCAXAAA=
+H4sIAAAAAAAC/9RYX2/buhV/lj7FqbYH+V5Pae9eBgfB4KZpFyBtgzjZMBTFQEvHFheKNEjKRjr4uw+k
+SImyLcfJOmDLgytR5z/Pn9/p2RlcitWTpMtSw29v3/3xD7+9ffcnmBakgluJiuFTBlPGwFIokKhQrrGI
+z87gQSGIBeiSKlCiljlCLgoEqmAp1ig5FjB/Al0ifL6+B0Zz5AoNpy6JhpxwmCMsRM0LoNzS3VxfXn2Z
+XcGCMsziOF3UPNdUcEhH8K84SmqFoLSkuU7O4zhqP+cl5o9/Ramo4A1ptCbSmvaZUDZjtVyhdARwAUly
+7kjyWkrkepAqjqIN5YXYZO58hnJNc8yWqM1jS5+O4iiKMl0iD8wuiCaNPVE0aI0hytbNq9V4RKc7+ShF
+9Ynqsp6nqvn4cHczOqY9OubpAQsiuoD0sBlUuYOvrECZHvZrPBzaUWtT9Ps0+d2TqP2XZJSVumIDIkfn
+AZeTvsM4rDPkdZ5+RqXIEpNRJrESa7xkRKk0KWlRIE88x9b+s21et80t50TnZRBolNL7FIRtWuuyi9kD
+J7UuhaQ/sLAMbRQOkC+FFjdiSXnqzNj28mLKUGpPi1IKaSU6E89jS96aZ1NVa8qXyuTNRyGroEiU+wQX
+jT0F0WhIiJ6ACVb3DmJl5E0UMsw1FskoWxOWjsaGjdRa3OFCoion4MxcEanwmuvUyAkIBgXBu7eNNF1i
+hY1++zjEEUfR1iasRF1L3jqzGwLKqaaE0R/oPDeS55rf2YtPRpngaZIzmj8mY+h1HRD8vae7NATp6Bya
+bHAyZmSNPr7PSwqpvag4ivodbNd8JkgxLSrKb2XN8R6rFSPau+Jc57iBWykqqjDITIlKsDWOQeI/Mdcu
+59z9eEE+k4yaNCGtosRm+15T046tTWCyZxpcwF8ILxjOiVRZLqoVZdgxutJyljsb21R3Wo8UWcdpnOpy
+35XpdjiAXej/e7HrkuEF4Zt1Zfg/Fbn99LeS3guhlZZk9YESJpZZLviCyiq1WqqmsU4gmUqEJ1GDqt3D
+hqoStICVyRYQrACsCGXqz0lT91Qzw/e36d2X6y+f3OHTCiewq/H+77dX/3B0liwnjM1J/jiB3hXWTIe9
+uX9iO6C15dJAlwvbcez7HeHLwbbjZ+ShdjxnIn9ME1MOlC+zLEtG4Uh943hmiIVnWRNGTZu99Yak1oSv
+VrkadwYGk3N4EiT3JUqEDVFAONgz2FBdWoTlPfEXYFVk7bBz6dGOvp6bdqo6VQUy1GhOrjVWKkAhoblO
+6G4FSLFR08XCGtJ5dEjNEu0svxQ11yHS8Sz7olGtBFcYiDVO8QJlv3f2I+zZssprayNi7i2YHv4uh+6g
+5k0ChPyqFBurfVbnOSrlgEe6OyZ7cQkEbAN/j9X2K/HHySCklxSnJyGspJgzrAwQMT0OTJAhN1FOel76
+59bfZ7x9na8netr5+bJSs5XReklNdQT1tW3xnPsZ6Lh9mHAIrB1EdeHC4r96k5UWspPpJR1cW8KG6Qmz
+Boi9ufDA/t689xopWa0e7m7gAgYsWKKeWpI2zI6QiZzoZhVxMn6F5MzOxaQ38Z4Fw6qpsDRp56kiayze
+JP/H+P359tV1rTZTzDpkwrmPGq3VWmjCrlq+SSfCztJQ/ATCN5eyDv6GWLHZwMzPgAf+SlpLfGqNoVsy
+nJrDjrTZu7eptFnaHY77NK03e0f7+0srLTgN95J+TRwISbAPDEdlaCzsj8ejmZ7ArxCymNppUFWqRs3d
+FYlXfvbLT/yLI/gFLgVXWta5FtK8/7y/s7hpKnsZfB58mLULX+wapMcIR9vQrCWzBdqiQJcRcAHfvrvz
+sNu1/ynkloWMMJZ+i6NoaEEbh9+6fh5H300jOtKHnm8UTcodQJNL1LeBLzuw6RnAtBMF/7VBPS8FaM+C
+s52RNnBfErWk2FubO/a9ag7l9ILyYZeyA3M7d9wvb0/0n6DIVzRAx3kIe56AO09ZBV8Dn04CT9sjdu5M
+u3bvPF4OLzf1BEO38emVtk0NIP93AAAA//+u9HAfLxcAAA==
 `,
 	},
 
 	"/www/mailslurper/js/controllers/HomeController.js": {
+		name:    "HomeController.js",
 		local:   "www/mailslurper/js/controllers/HomeController.js",
-		size:    14153,
-		modtime: 1527568115,
+		size:    14105,
+		modtime: 1542252810,
 		compressed: `
 H4sIAAAAAAAC/9w7XW8bOZLP0q+o6xvgWonctmeAvTs5yiKJkxsDdjawHSyC2XmguksSNy1SINmynYH/
 +4FFsr9blmdyh8HmwRiRVcXqYlWxvub4GN7J7YPiq7WBH09Ofzr68eT0v+BNxjbwSaHO8SGBN3kOBKFB
@@ -16851,36 +16914,39 @@ NeR+UUxjhJXmJetiwwT/hjFVESfRAd6ijs70DaZSZNYPHsHpyRQi7Ra6fYqqSR2mLnyp0c/lVB647JWW
 tbtu+bEzaffUCOz/OLsMhz81B2t/vn24OO+Zgj1o7rVbHi0hzv4FB2NXXrr0f5lYMf2HDpLuG4z9fv/c
 ZLsU2qgiNZJs5vv9Ox6Tew+d6V9+PasWaO7zxC+0Cr1huVY5DktN4wqrjdZ2Y7HeyC5Pq4YwB2sDrbJA
 RAlELXadDeecFeR7ke3t39SrCfUTbqX9TfftOKyVrzx/9ULqzFeIp9X6eVX7cmXuilj/zJMo8rwG0BrW
-qe0Oz5M4oAAVzH44OllhMI3P15fxkyEM/a4iGfI+exyW9ZdcrJyX8jMeCcvz+JfxaDQ4mDatbTbnqMLO
-4NDPePSr9TjOszUiA1oenkh4vic6wBE9jscHuyEBtFZ6oSqW/7eo7Os9WpH/bwAAAP//hiRMvEk3AAA=
+qe0Oz5M4oAAVzH44OllhMI3P15fufd7jgKz/42LlvI6f2UhYnse/jEejwUGzaW2zORcVdgaHeMajX60H
+cZ6q8dLT8vCEwfM9ywGO5XE8PtitCKC10qtUsfm/RWWf7tFGz/8bAAD//3hGPcIZNwAA
 `,
 	},
 
 	"/www/mailslurper/js/controllers/LoginController.js": {
+		name:    "LoginController.js",
 		local:   "www/mailslurper/js/controllers/LoginController.js",
-		size:    2050,
-		modtime: 1527606791,
+		size:    2097,
+		modtime: 1542257776,
 		compressed: `
-H4sIAAAAAAAC/6xV3U7zOBC9Tp5i8O5FwnZTfm5WVNEKIVZCYhGi8ACuM2ksXBuNnVbVqu++suOkafvB
-913QO2fO+HjOnJlOp3BnPrYkl42Dq4vL6z+vLi7/gtuKr+CZ0CrcFnCrFASEBUKLtMYqnU7hzSKYGlwj
-LVjTkkAQpkKQFpZmjaSxgsUWXIPw78MrKClQW/SZruEOBNewQKhNqyuQOuAeH+7un+b3UEuFRZpmdauF
-k0ZDlsN/acJai2AdSeHYLE2TIbxE92aRnvgKO2RC6FrS8HvGfmtjhOXFmqssn6XJ7ij5mVu7MVSdJn/E
-yGfJa65kxR3+Y2gVs9ecvE6tclCGD4lthUBrb8BRixP/ZYXW8iXeAGPhXEtUlT+lSbLzpSWOtl2yrCE7
-rK8sS2CsI/OP9VRFuAFKYEO5sxB2DZkNaNzAPZGhjD0r5BYBtUMCDh4OOsgTEnx1A+lIl69JB5l+jXSv
-auRMkh0I7kQDGRJFlkgS1YMSaq4szkahKCOUgET9yQNCFbGNHfa4cbZdrKR7NEupM9w3LvZTGv3St/Cw
-xaE5Xp6zY2j/0Ph67x4Gf5zc2ImWF7URrc06AbhCctkJMhaUx5JDNYMGoUT/ZD+RUuDbyyOUsJG6Mpti
-js5JvbTzLlYs0c0HWBYzelBXU8y8bV3TZ6mgzv7+yeGgTQ5HJ/evLFyDejS3zryj7l3zAwrrDOGrB0Vo
-ZyAvXk2r0B6WF12zoli7jijYZcS0903Po4wIanqDTkMtf0dFywcdxN67HwzBoYl3/axPz7/xlyZwDndG
-W0etcIb8+ft+03TsiL6/fg2FpeJVXTg9D2qyvDA6Y0JJ8c4m43nwhR8tTo98x+0HobVsAiPVO839QGCx
-aaRowqa4vM771bcfs7yzbafs0XL9doI0+eko9JHMG+rYuLYfjkhzImkPCGb5hCu4+5jtdPqip7+wtDDa
-GhUmMnwdbQ0WVqwfRX9d3/vheWcwR//HPOSzSDhLd1mez/4PAAD//2ukW5cCCAAA
+H4sIAAAAAAAC/6xVwW7jNhA9S18xy/Yg7bryZvdSrCEURpACAdJFECcfQFMjiwhNGkPKhlH43wtSlCzL
+TdNDfKP4hm/mvZnxfA63ZnckuWkcfPt68/23b19vfodlxbfwSGgVHgtYKgUBYYHQIu2xSudzeLEIpgbX
+SAvWtCQQhKkQpIWN2SNprGB9BNcg/HX/DEoK1BZ9pGu4A8E1rBFq0+oKpA64h/vbu5+rO6ilwiJNs7rV
+wkmjIcvh7zRhrUWwjqRwbJGmyXC9QfdikX7yLXbIhNC1pOHXjP3SxhuWF3uusnyRJqdJ8CO39mCoug7e
+xZu3gvdcyYo7/NPQNkbvOXmdWuWgDB8S2wqB1v4ARy3O/JctWss3+AMYC+daoqr8KU2Sky8tcXTsgmUN
+2WV9ZVkCYx2ZT9ZTFeEFKIEN5S7CtWvIHEDjAe6IDGXsUSG3CKgdEnDwcNBBnhDgqxtIR7r8N+kg0/8j
+PasaOZPkBII70UCGRJElkkT1oISaK4uL0VWUEUpAov7kAaGKaGOHnRpn2/VWugezkTrDs3HRT2n0U2/h
+pcXBHC/Ppym0TzRm77uHwZerFzvR8qI2orVZJwBXSC67QsaC8lhyqGbQIJToU/YTKQW+PD1ACQepK3Mo
+Vuic1Bu76u6KDbrVAItFROiydU0PU0GO84Ozy8maXc5K7tMqXIN6NKjOvKLu2+RfKKwzhM8eFKFdx3i1
+atoGP1hedO5EdU4dUeiPEdO5UYIMfLd7T4JlgMRX++SUEUFzKPsnvgCbByX+iAaU9zp4cx4WMASXPX/q
+V8P88wf+0gQ+w63R1lErnCF//rjfPB03UC+Y31phB3lP1k6vghcsL4zOmFBSvLLZeHx84ZM965GveNwR
+WstmMPKsc8zPDxaHRoomLJab73m/Kc9TmXdd3ik72cUfTpAm705Of5P5dpy2vY2XPc2VpD0gNMsbXGE2
+pmyTp7qkQwpvD4Qw2hoV5jl8HS0ZFjayH2T/XO/9kN4nWKH/Hx/iWSRcpKcszxf/BAAA//9DBbXSMQgA
+AA==
 `,
 	},
 
 	"/www/mailslurper/js/controllers/ManageSavedSearchesController.js": {
+		name:    "ManageSavedSearchesController.js",
 		local:   "www/mailslurper/js/controllers/ManageSavedSearchesController.js",
 		size:    2038,
-		modtime: 1527543303,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/6xUTU/jSBA927+i5OXg8OGE7GW1IQeE0EwkGCGFOSEOnXbF7qHTHVWXwzAo/33ktp3Y
 SWCQBh+sdLrqvapXr9zvw5VdvpDKcobh4Pzfs+Hg/D+4TMUC7gidxpcELrUGH+GA0CGtMA37ffjuEOwc
@@ -16898,9 +16964,10 @@ Y0WqTJYkSeSX5Y/mDvcNV0/7b7bsYImFqYqsvRK+67VDAEhkaeO60m3rsoDfAQAA//8Us3cw9gcAAA==
 	},
 
 	"/www/mailslurper/js/services/AlertService.js": {
+		name:    "AlertService.js",
 		local:   "www/mailslurper/js/services/AlertService.js",
 		size:    1741,
-		modtime: 1521001643,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/6yUQU/jPhDF7/kUTxaHVEAK/C9/AUFCCO1WWlYrsdy4uM6ktXDtynYKFep3XzlJ2yRN
 u12JnKr6+f2SmXkzHOLBzJdWTqYeVxeX/51fXVz+j/uMz/DLklO0THCvFEqFgyVHdkFZNBzixRFMDj+V
@@ -16916,28 +16983,31 @@ WmN3XKtzsIzrCdmGxz4kfQjFZzyU6Uiw1Lmx1Y29+KA5Ah5kPdTDJVdm8lR5ddraaEEX9srubofyDgyn
 	},
 
 	"/www/mailslurper/js/services/AuthService.js": {
+		name:    "AuthService.js",
 		local:   "www/mailslurper/js/services/AuthService.js",
-		size:    1589,
-		modtime: 1527564184,
+		size:    1649,
+		modtime: 1542257763,
 		compressed: `
-H4sIAAAAAAAC/7xUzW7aTBRd46e4n/UtjEJNkm4qkFWlKVUj0RQFoi6qLgbPsT2pmUnvjIG04t0r/wEB
-0l27GY3uz7nnnmNPv0/X5vGJVZo5ujy/eP3q8vziDV1JsaAJw+Z4Cukqz6mqsMSw4CWk1+/TvQWZhFym
-LFlTcAyKjQQpS6lZgjUkzZ/IZaBPNzPKVQxtUXa6TDiKhaY5KDGFlqR0VTe+uR7dTkeUqByh5/mFBVnH
-Knb+0PNWSkuzCq8Kl03BSxWDIvrldXKTKj2gpNCxU0ZTYOvs/d24R4UF34oFevQorF0Zlt2yp8NwBWvS
-WNGEzUJZBDsAhjX5Ej1iPCB2dUfn/1A8iHVQ3TsF5wPaDaIz8vsVEb9X5RdwmZED8iefp7MmJoUTgxqr
-02mJDXYU60TLc7BlXMU35bnphi6DDqrIjq8z36G7LXKzWrNEkxzWID3voJVhH422OO4uN9+mw/Yyw9q1
-YOVZ3TflWWHnJjWFO23GXxXeFO5Q+fej8Wg28v+g20uS/Su1rDOMWenPvmJ7buYmFvnUGRYpvvoPK+d/
-o4iqghYjhTtCeKb0CYy2twIarZV19kY3JS/iBKfI/BdFVGiJRGnILr0lxwVoQInILdoxErFh4XCHHwWs
-+6JcVv7EhtVPUQ7aH8l1zUSwWMCBbc1BJRQc///hqQWCbuPOEVQ4R2IYU2hJ0d7MdcatoeuMQwvXMP0I
-IcGB/4yt3yP/HQSDyaczOsGqtSTo1t6X1m88b+9rOSDWCqXsvRbNLMh9WcC8EwLMFEUR+R8Mz5WU0P52
-5WpAacLwYOgzR1LjzPjw2awxmn1Ks6twtH3YymZvM/R+BwAA//9pghzpNQYAAA==
+H4sIAAAAAAAC/7xUwW7bOBA9W18xK+xBRrxykr0sbAgLN3XRAG5qxA56KHqgxZHEVCbd4ch2WvjfC1JS
+7NhOb+2FIMiZ9968J6rfhxuzeiKVFwzXl1f//nN9efUfjKRYwpTQlvgUw6gswVdYILRIa5RBvw8PFsFk
+wIWyYE1FKUJqJIKykJs1kkYJiyfgAuHD7RxKlaK26Dq5EAyp0LBAyEylJSjt6ya3N+O72RgyVWIcBGFl
+ESyTSjkcBsFGaWk28ajiYoa0VilCAj+CTmlypQeQVTplZTREtr59uJ/0oLJId2KJPVgJazeGZNf1dAi5
+Ig0aNzAls1QWoz0AoTXlGntA+Igp1x2dv2PxKLaR33cqKgewJ4ILCPteSNjz90vkwsgBhNOPs3lzJgWL
+QY3V6bTCBnuJ9UWrc/Cs2J/v3LrrxlygjvzJXi+br6i7LXIzWjNEczmsQXrBUSuhXRlt8bTbTf58Hbeb
+OW65BXOr3+/c6rFLk5uKz4fxW403FR87/3Y8Gc/H4S98e82yP+WWZUM4d/kcOnaQZmlSUc7YkMjxc/i4
+4fALJOALWowc+QThhdNnMNpeDzTeKsv2Vjclr+JE58T8lSRQaYmZ0ii78D8wVQgDyERpsaWRmBoSjPf4
+rULLnxQX7hEbUt+FIzqkpLpmKkgskZFsrUFlEJ2+//jcAFG3SecEKl5gZghnqCUkB5zbgtpAtwXFFrlR
++h6FRIrCF2rDHoRvUBAShHABZ1S1kUTdOnsX/S4IDr6WI2GtUco+aNFwoTy0BYn2RiARJEkC4TtDCyUl
+6vB5ZE/gQhgekb5IJDdsJse/zRpjLQjEauWeVtION0NmpXN7MODIl9Qvpaly34dHSlqA/U/REQe7YfAz
+AAD//+fy7URxBgAA
 `,
 	},
 
 	"/www/mailslurper/js/services/MailService.js": {
+		name:    "MailService.js",
 		local:   "www/mailslurper/js/services/MailService.js",
 		size:    4170,
-		modtime: 1527563342,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/9SW32/bNhDHn62/4iYMm5M6cn8AQ+HAGFLbHTwkWdG4GPJIiyeLKUVqJGVHG/K/D0fR
 sWxXW1bsoXkxTB7ve8fjh0cNhzDRZW3EKnfw+uWrN2evX756CxecFfDBoJVYJ3AhJfgVFgxaNGvk0XAI
@@ -16962,9 +17032,10 @@ ikCol8ywwsIY/v/3ojKy62Vo7kx4qZoUvs3HIno4j/4OAAD//6Io2uJKEAAA
 	},
 
 	"/www/mailslurper/js/services/SeedService.js": {
+		name:    "SeedService.js",
 		local:   "www/mailslurper/js/services/SeedService.js",
 		size:    1998,
-		modtime: 1526609524,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/4xVXW/jNhB8ln7FQChQ5+LIzhUHFE7z4MZpL0XcBrGDNjjcAy2tLF4pUuWHP3rwfy9I
 yd8p2hdD2p1Zzi5n5V4Pd6peaz4vLd73r7+7et+//h7DnFV40mQErVMMhUBAGGgypBeUx70eXgxBFbAl
@@ -16985,52 +17056,55 @@ uxK8OK7/KaQ/p7tTcHt7e3rmztlWOwoL5L2wifeWL5gwPrOJNzfxPwEAAP//55QVFc4HAAA=
 	},
 
 	"/www/mailslurper/js/services/SettingsService.js": {
+		name:    "SettingsService.js",
 		local:   "www/mailslurper/js/services/SettingsService.js",
-		size:    4173,
-		modtime: 1526607195,
+		size:    4113,
+		modtime: 1542257473,
 		compressed: `
-H4sIAAAAAAAC/6xX32/bNhB+tv6KmzB0duvISfdSyFWHrM2GDE4bxMlDUPSBlU4WA5kUSMqJUeR/H/hD
-jihLcTcEBRqL4n28++7u42k2g4+82gq6KhS8PT75/ejt8ck7OM3IGi4FyhK3EZyWJZgdEgRKFBvMgtkM
-biQCz0EVVILktUgRUp4hUAkrvkHBMIPvW1AFwsX5NZQ0RSZRW6qCKEgJg+8IOa9ZBpSZfYvzj2efl2eQ
-0xKjIAhriSCVoKkK50FwT1nG76MlKkXZSi5RbGiKkMCPYDR7/ToYwWsgWbYkG8yWSERawD0tSyBVhSwD
-AgzvQeq3IM1rbTELRr5NDHnNUkU5gzEja5y6zR8FVSgomejjRv5apDdCAvrPPBiNNkRAWguBTLWQUUIC
-/UFEApWguEFv+3gyD4LRqA8pqmpZjDue6aMH8KXiogPeB6shHqdBMMqwRIUDtFCW4YPl4WUjpbkDhw9w
-dAKvXoF9et97RlQiW6nCOtLPkqx02VnMKZwYhl6AotGjo6kpuxW2N/25PTduC1S1YBKIV3XwnUjMgDOg
-SkLJU6JZNTCuDYgQZBu56uyFfiYb8oUy8B6OnxLwIdnh+qyflihUA4xCcDH+AWuUkqwwhvC6QGEUgfEO
-B1urAuefQni0abFsWdiR7qQYwnBqnqzRxQ421KuPNhHBzrLx8Kvx+du8J0fW0YYQKw/O2ugUoeWyrEWF
-mkcrL4qi0LIiUEorMSyDigvVTpCP286O5cmdoQXoUvA1lTh+2iJQ8nKDUxB4h6lyzP4akTvyMLZ0rFEV
-PIsh/Pvs2nFSizKGcObclO5oy8wkUgWysdnnnVOXDfzOJ3d689akQhPn26IQ+4baW/PGGen/bXtMBrm/
-uVq0+iKvy3ILORdropSpDkv6zdVij92bq0WbWOlz3m4AP8mH+8A3GE/mPtKpTT4kXejI37BroK5dkkB4
-HJl/oWNxD9r52MhBVHCpmuvEFLl2qBJc8ZSXkOzFH1G5XC4m8AeEhVKVjEOI7c847MSjU5A8Yb2BcDYL
-4U033DcQxq3lbtCXXKh5u/ka7G7f9coNCCSZ9DQBJeSCr40ilqDVmKzQVUEvxn6bafKN+dJafw1l2yD8
-5th3Pv+z/PI5qoiQeMDKJAGwlOjZf/3WdxcMlJWLeEhmmgY2EIYHvbOWKH6TPiVRl5OfFJ/haH0AG+9A
-SF4s2rud4z3J2/d0yMWexD1585M589zvS5eVr4wo/MsITgzh7e3t7dHFxdGnT1AU8XoNp05dSa34FeYC
-ZRHDsV1TBZpLKcOc1KVqX0I+XR1Czx6oVOds0biLOwFUosZZTrSjVE/SptyfLQ8g+j5lB4vjkAuDVXKo
-NuCXJIGaZZhThtlepewPUXapKRa/3ynr7fZ9EE/4vWnM+P5s90Jii0Z/SLAVzbcdhP4QupOCnrEPdy8o
-bjAOpqfnjIOX26HM7MfZQRmI1A/Rb2rF/QDM9FNXuonkLlLTGE1VtulJOcvpynzO+YH3RdwO9X/MS0Nq
-0EfLjo+9QctNVSYiJwW72evyy7IZvjKiyPW20mqg8EG51ZQzhUy5F6TSHx/mNp/dSc7mkBZat1RSq/zo
-XQsp7nroBi0nOI2/kXm2o9bkmTlvaMIbmu0eCjEFM7trz83P/zTr6bIKHufBvwEAAP//6VTFLU0QAAA=
+H4sIAAAAAAAC/6xX3W7bOBO9tp5iPqOo7cKRk343hV0XyLbZRRZJW8QJiiDIBSuNLBYyKQwpJ0aRd1/w
+R44pS3F3UQRIIpFzeObMD0eTCXyU5Yb4Mtfw9vjk/0dvj0/ewWnKVvCVUBW4ieG0KMDuUECokNaYRpMJ
+3CgEmYHOuQIlK0oQEpkicAVLuUYSmML3Degc4fL8GgqeoFBoLHXONCRMwHeETFYiBS7svovzj2efF2eQ
+8QLjKOpXCkFp4onuz6LogYtUPsQL1JqLpVogrXmCMIefUW/y5k3UgzfA0nTB1pgukFGSwwMvCmBliSIF
+BgIfQJlVUHbZWEyiXmgzhawSieZSwFCwFY795o/ENRJnI3NcL3wXm40wB/NnFvV6a0aQVEQo9A4yKphD
+uxMxoSaOawy2D0ezKOr12pDislL5sMHMHN2Br7SkBngbrIF4GkdRL8UCNXbIwkWKj06H3+spzzw4fICj
+E3j9GtzT+9Yz4gLFUueOSLtKqjRp5zDHcGIV+g0S9Z68THXaLXF30x+bc0ubUFckFLAg6+A7U5iCFMC1
+gkImzKhqYXwZMCK2iX12tkK/EA31myLwHo6fA/BhvsUNVT8tkHQNjESShj9hhUqxJU6hf50j2Y4gZEOD
+jesC55/68OTC4tRysD1TSVPo98f2yRldbmH75u2TC0S0tawZ3lnO97OWGDmitSCuPXhr26cYLxZFRSUa
+HV170RzJtBVCpVyLESmUkvRugELc3eg4nfwZpgF9JbniCofPWwiVLNY4BsIfmGiv7KuY/WCPQyfHCnUu
+0yn0/zq79ppUVEyhP/E0lT/aKTOKdY5iaPcF51RFDb/l5E+vV20ojHChLRLtGxq2dsUbmd+uPEad2t9c
+XezURVYVxQYySSumtc0OJ/rN1cWeujdXF/vCuowPo3o48UOD4WgWIhmO8yZsXFFhS6Rt083VRUxYFizB
+4eA4tj+Dcc2jrvE4l0qbzHa1tk3bGqIlY799exbMpmhTMVaWoVqnZdmqlMd4NRysULM7Q2POyvKoouJ+
+MIqZ1jQcJFJoFHrQjF9rywBClqqgrlFBRnJlu1oBpqOyJXpurRj7PE0HsuYLZ33XV7sG/Xufh96fvxdf
+PsclI4UHrGxeAhYKA/u7+7Z+3pEp3uOuVlEXoYWwOpidlUIaqFCSuKnJLzaQbm9DAOdvh0uBL4bdlnhL
+8PaZdlFsCdwzm1+MWUC/LVyuBaVM45+2BKbQv729vT26vDz69AnyfLpawanvkKzS8gozQpVP4di90zna
+iyXFjFWF3r1IQrkagp49cqXPxUVNF7dNTFOFk4wZotxMwzbdX0wPYOZOFAeT4xCFziw5lBvwv/kcKpFi
+xgWme5myPwi5V3WyhPXORWu174Ps0g2K03F/sXph7pLGfAyIJc82DYR2F5q3vZmTD1cvaGkxDoan5YzA
+x3Cp1cu9yOz72UDp8DR0MSxqLUMH7ARTlaaI1NZTWxh1Vu7Kk0iR8aX9JAsdb/N419X/MPN0dYM2WbZ6
+7A1LfjKyHvlWsJ2fvn5Z1ANUyjS73pSmG2h81P6tvwH9AivNB4S9vCc/lBQzSHLTt/S80tnRux2kaZOh
+H5Z8w6n5xvbZjUujF2a1rimtaz57zGkMdv42zO2//2peM2kVPc2ifwIAAP//AJkZgREQAAA=
 `,
 	},
 
 	"/www/mailslurper/js/services/TemplateService.js": {
+		name:    "TemplateService.js",
 		local:   "www/mailslurper/js/services/TemplateService.js",
-		size:    484,
-		modtime: 1521001643,
+		size:    545,
+		modtime: 1542257498,
 		compressed: `
-H4sIAAAAAAAC/2SOwWrcMBiEz6unGEwPDtlaSXopXXoIIYdAWwLZPoBXHq9VZMn8ku2a4ncvcjctbS8/
-P8zMN6M1HsKwiD13CXc3t+/e3t3cvsd9U/d4FkbHpcK9c9gcEcJImdgorfE1EqFF6mxEDKMYwoSGsBHn
-MFE8G5wWpI74/HSEs4Y+MidTVyeY2uNEtGH0DazffJ+eHh6/vDyitY6VUsUYiZjEmlQclJqtb8JcHdkP
-rk58oUzWEB/xQ+1cqJsPaEdvkg0epa97XmVhJ0yjeHjOeJbQ28jyj00Yg5u4h/AbTfqV2L2pzkxloed5
-1n1tXXSjDBSdLs1RF7hGrsA1iqo7xeKqSh19mdO7v/Cje6X+nnIpfVUPm7ju/8l+72QPigQ5LgO3939Q
-Hl1m5QLJd/vXfFe1HpT6GQAA//9N8bAE5AEAAA==
+H4sIAAAAAAAC/2RPzWrbQBA+a5/iQ/QgE1dK0kupycGEHAJpCbXzAGvps7VltStmV1JN8buXVeWWtpdh
+mO93qgqPvj+LObUR97d3H97f3959xLbRHV6FwfJcYmstZkaAMFBGNqqq8BYIf0RsTUDwg9RE7RvCBJz8
+SHFscDgjtsTn5z2sqekCkzK2OqLWDgfi6AfXwLiZ9/L8+PRl94SjsSyVyodAhCimjvlGqcm4xk/lnl1v
+deSOMpqaeMAPlVmvm084Dq6OxjsUTndcJSATxkEcHCe8iu9MYPGHJgzejlxD+I11/KXIRi3Qff/29QUP
+WFJ3jNG4U1hSyxPjdqYUq03SvEuXYlHdIK+maao6bWywg/SUKi61Q5XjBqlfopXtIeSrMrZ0RbLJ/uo2
+2Gul338sja/onJ1d1v9ov7eyBkW87M895/V/o/RxkZDFJM15v6R5UZeNUj8DAAD//78hrWwhAgAA
 `,
 	},
 
 	"/www/mailslurper/js/services/VersionService.js": {
+		name:    "VersionService.js",
 		local:   "www/mailslurper/js/services/VersionService.js",
 		size:    1426,
-		modtime: 1521001643,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/9yTQW/aQBCFz/hXjKwejOQa7F4qIJGiiEZIaRsV0kuVw2KP8aL1LppdQ1Dl/155vUAw
 Laeeclmtdr558+aBBwO4V5s98VVhIBnGnz4mw/gz3GWshCdCLXAfwZ0QYAkNhBppi5k3GMCzRlA5mIJr
@@ -17045,133 +17119,142 @@ I5o4p39XapnbLnOu5BKcuEUulM6berVXjz3vTwAAAP//i1rE85IFAAA=
 	},
 
 	"/www/mailslurper/js/widgets/SavedSearchesWidget.js": {
+		name:    "SavedSearchesWidget.js",
 		local:   "www/mailslurper/js/widgets/SavedSearchesWidget.js",
-		size:    2389,
-		modtime: 1521001643,
+		size:    2454,
+		modtime: 1542257741,
 		compressed: `
-H4sIAAAAAAAC/9SVwW7jRgyGz9JTsGoPIyArJ+mlsOvDbnaBGm22Qb1FD0UP1AwlD3Y8Y8xQzhoLvXsh
-ybKkxGnSIpfmEMEkh/z4ixzNZnDjdgevyw3D9eXV92+uL69+gLcKt3DnKRg6ZPDWGGgjAngK5Pek4tkM
-fg8ErgDe6ADBVV4SSKcIdIDS7clbUpAfgDcEt6tPYLQkG6g5yRtkkGghJyhcZRVo28b9srr58HH9AQpt
-KIvjpAoEgb2WnCziWBSVlaydBZHC1ziO9ugh4J7UmtDLDYVbp9B8ou3OINNiCOj8D7xxdK+tcvdZb1qT
-32tJmXGoRPI4cZJmvCE7wuDjyQYnip5GgSX8hFYZytGHTLrtThsaTi/iqE5fBDRq5CU0Z/r+lyjrcU9/
-aFUSw7LLv3H3d1p+Jj+HgUGiMTnKzx1D+wKURuPK36iAJbxzjgN73L1vjVmTRLSREWs2NIekrQh9yeSi
-dW4pBCxp/g+vW3ydOufQt0DM2pahV9MTe017mrQmUqjTrpY0LmDesLCvqLNZc503faIJR0teMTsb5vBn
-+zPqmogireaQ5Gxv0WI5rXHsJYoM5mTmkHQxJ7MM4cZgCF2CN4oKrAyf3NhKPBb7KHLzd+zVOImtbwnJ
-rJUj9MUXx9C6e9YX57lv0EoyI+5H1F3Ef6c+zcMI/2TLGvVJpC+k/fXnR3gj0wO0nddb9IeXCfrgboHl
-U+NUEo/UendYWUVfxDF4hz7QyrL4TiTfjtKt3oPbtdUDGZJMKkmzPRqRXsDVZXpqP+r3SYwOD95nZWsf
-fzX/69ZXX8TH1V1Pr4fX32GYjM9kgc9cS+JVl28Y4v/BDA+YrzzN5yCnX8SPuG0+CM1w8hdeT+z9QJ6G
-TRcgpkczQ7bkDfy4hMtRjQgNeRbJnSEMBGSZPCDYpljhPBxc5aG7l75Jhvw1kAk0SvOkoA/WYgAaJTu7
-CJ1WzjYj+4xUT2lSOFmFHqUebVYc1Yu4Fmm6+DsAAP//eP2esFUJAAA=
+H4sIAAAAAAAC/9RVwW7bRhA9k18xZXsgUYey3UshVQfHCVChcWpECXooehjuDqlFVrvE7lCOEPDfC5Ki
+SNpy7Ba+RAcRnJmdee/NzHI2g2tb7p0qNgyX5xe/vLo8v/gVriRu4daR17RP4UpraCM8OPLkdiTD2Qw+
+eQKbA2+UB28rJwiElQTKQ2F35AxJyPbAG4Kb1UfQSpDx1JzkDTIINJAR5LYyEpRp496trt++X7+FXGlK
+wzCqPIFnpwRHizCM88oIVtZAnMDXMAx26MDjjuSa0IkN+RsrUX+kbamRaTEEdP573jC4U0bau7Q3rcnt
+lKBUW5Rx9DBxlKS8ITOCwYeTDZwgeBwKLOF3NFJThs6nwm5LpWk4vQiDOnkWoBGR56A5wfs/QlmPOf2l
+ZEEMyy7/xt7dKvGZ3BwGDAK1zlB87jC0DZAKtS0+UA5LeG0te3ZYvmmNaZMkbiMDVqxpDlFbEfqS0Vnr
+3JL3WND8G+2Ov06dc+gpELMyhe/VdMRO0Y4m1OIE6qSrJbT1mDVY2FXU2Yy+zBqeqP3BklXM1vg5/N2+
+Bh2JIFByDlHG5gYNFtMaBy5BoDEjPYeoizmahffXGr3vErySlGOl+ejGVuKx2AeRg4PQWJafPryD5WPE
+C+KrNiRu2tz9DqHaCmxzLvssP0M0a/X0Pfr+TN0967PTxK/RCNIj4g9odxH/n/ZxoEb8j7a0aR8NDJ9A
+++cfD+CNTPeglU5t0e2f35HRQH6zLSO1Xu9XRtKX+BBcovO0Mhz/FEc/jtKt3oAt2+qeNAkmGSXpDnWc
+nMHFeTI0uF/IeHR48D4pW/v4p/mvW199Fh52fz29X17+EoDJ+ExugBP3Wvyi2zsM8XcwwwPMF57mUyCn
+n9T3uG2+KM1w8hdeT+z9QB6HTeUQT4+mmkzBG/htCeejGgFqchxHt5rQE5BhcoBgmmK5dbC3lYPuXvoh
+GvLXQNrTKM2jgt5biwHQKNnJRei0sqYZ2SekekyT3IrK91Dq0WaFQb0I6zhJFv8GAAD//5gDnAWWCQAA
 `,
 	},
 
 	"/www/mailslurper/layouts/loginLayout.gohtml": {
+		name:    "loginLayout.gohtml",
 		local:   "www/mailslurper/layouts/loginLayout.gohtml",
-		size:    2057,
-		modtime: 1526606682,
+		size:    2451,
+		modtime: 1542258342,
 		compressed: `
-H4sIAAAAAAAC/5yVwXLjNgyGz9ZTIDxX5ia97EHSNE1zyMxuuzNOZtojRcESHIrUkpBcTybv3qFke9Vs
-sl7nYEsggA8Q+UPKLv746+b+ny+30HBriiS7SNNESrhx3c5T3TBcfbj8Nb36cPkRrivVwhePweBuCdfG
-wBgRwGNAP2AVEx8CglsDNxQguN5rBO0qBApQuwG9xQrKHXCD8PnuHgxptAFjJjeKQSsLJcLa9bYCsmPc
-p7ub2z9Xt7Amg8skTYski82CUbbOBVpRJEnWoKqKZJG1yAp0o3xAzkXP6/SjAHn0NMxdil97GnLxd/pw
-nd64tlNMpUEB2llGy7m4u82xqnGeaFWLuRgIt53zPIvdUsVNXuFAGtPR+AXIEpMyadDKYH75PafCoD11
-TM7OUJ8VmZXpfYceVnFHPaQwLgRoFRkgyw5caWggZy++x6qeG+dnxPmRQaYq1f4W/7r9IWrXFiMlWWSG
-7CN4NLkgHbtqPK5zIbfbrYy1w9SXpFbVGORaDTFsSdodAExssPjkarIgJcweJpOT71jmDTY32GKQT0/L
-+3j3/CxL5ziwV91ShyCm9gLvDIYGkQVQlYsx6/dD4GrmHbfnZcG1s6y2GFyLUocw2ul+4Y0qr3JM1H7p
-/r0aKQfrHMLx4dKKlHH1CHq5+E6gYvTK1tiRfkQvX9jnQH98QGP6qcNZnVNj3M0oorebzOQ07UlWumoX
-gRUNoI0KIRdR+4oseojO9GiKIlksnp4Y284oRhDRLWD5/JwsMlnREDkXaQpy+Q0xvmzkVCXJppmF4PW+
-b9u5+FtugigyObmLV+Ja16Ll/eVkdKNsZbBUPsxuT2Ztvvbod/vLyejSOP3Y0yF8NB/uTqcdFCY3M6n+
-fNpJYZ5BmmZm88rI/Dyk9m5rjpvw/+WTmG9vgM3sBXBSCzOtb4KMX07SGOQKmcnWYTUtvJtz3XPzOiOZ
-q38TJu3HYYpf/v8CAAD///oQrDcJCAAA
+H4sIAAAAAAAC/6yWwXLjNgyGz9FTIDqX5ia97EHyNE1zyEy2zdTJpD1SFCzBoUgtCdn1ePzuHUqxV80m
+TbzOwZZA4v8gEAJG2elvf1ze/X17BTU3Zppkp0IkUsKla9eeqprh/NPZz+L809lnuChVA7ceg8H1BC6M
+gd4jgMeAfollFN4HBDcHrilAcJ3XCNqVCBSgckv0Fkso1sA1wpfrOzCk0QaMSq4Vg1YWCoS562wJZHu/
+m+vLq99nVzAng5NEiGmSxYcFo2yVp2jTaZJkNapympxkDbICXSsfkPO047n4nILc79TMrcCvHS3z9C9x
+fyEuXdMqpsJgCtpZRst5en2VY1nhWGhVg3m6JFy1zvPId0Ul13mJS9IoeuMnIEtMyoiglcH87HtOiUF7
+apmcHaG+KDIz0/kWPcziiXoQ0C8EaBQZIMsOXGFoSc6efo9VHdfOj4jjkkGmStX8Ev/apyJq10x7yjNM
+24rOmxFns5ncdoUh/fDwcP/nzXa7Uxmyj+DR5CnpmEvtcf6Cu1ytVjKmEIb0JDWqwiDnahl1E9JuR2Ri
+g9MbV5EFKWF0Jpkc9vZx3xuMa2wwyM1mchfvtltZOMeBvWonOoR0SCDw2mCoETkFKvO0V/26c5yNdvtj
+f/MJ5s6yWmFwDUodQm+Lp4VXwr4PbGLXFe6f8x67s45C7s9DlKSMq3ry88WPiqAYvbIVtqQf0ctn9lFR
+/r/qPe+tis+OCtpXJL67r6eRyWFWJVnhynWMUNIStFEh5GnsOEUWPcRNsTfTaXJystkwNq1RjJDG7RQm
+221yksmSlpFzKgTIyTdEPyrlECXJhokDwevXErGti7/JIqTTTA7+0/cIG9eg5afL4fJa2dJgoXwY3R6O
+WXzt0K+fLofLC+P0Y0c7fW/eX/8AZ/emy8Woh47gvNkxx6CHdl+80O1HUCvvVmZ/kP9dPpz7bd4tRuPu
+8Jd01KaLIOMnC2kMcobMZKswGxY+DnzRcf0yNBl38iIMfRwHQ/wG+zcAAP//sZfv6JMJAAA=
 `,
 	},
 
 	"/www/mailslurper/layouts/mainLayout.gohtml": {
+		name:    "mainLayout.gohtml",
 		local:   "www/mailslurper/layouts/mainLayout.gohtml",
-		size:    4452,
-		modtime: 1527310639,
+		size:    5184,
+		modtime: 1542258342,
 		compressed: `
-H4sIAAAAAAAC/7RXXW/bNhe+tn8Fo/fmHTCabXdTDJKxLM2wAOla1M4+Lo/FI4kORaokJdcw/N8HUh9R
-XKdu6u4iEUmd85xPPjqOL968u1r+8/6aFK6U82l8QemUMXKlq60ReeHIqxcvf6KvXrx8TS45lOS9QStx
-OyOXUpIgYYlBi6ZB7hXvLBKdEVcIS6yuTYok1RyJsCTXDRqFnKy2xBVI3t4siRQpKote0xXgSAqKrJBk
-ulacCBXkbm+urv9YXJNMSJxNKZ1PY+8skaDyJEIVzafTuEDg8+kkLtEBSQswFl0S1S6jryPChjeFcxXF
-j7VokuhvendJr3RZgRMriRFJtXKoXBLdXCfIcxwrKigxiRqBm0obN5LdCO6KhGMjUqRh8yMRSjgBktoU
-JCYvP8fhaFMjKie0GkG9BSEXsjYVGrLwGTWEknBgSQlCEqGcJnolRSO0uvgcFmpXaDNCHJeMxMCh/MX/
-q7oiprqcB5TpJJZC3RODMolE6r0qDGZJxDabDfO2besXEyXkaFkGjRebiVT3AE44ifPdbrb0i/2eMEZG
-EcWsFRhsPWHAFViiZR7Hr/Z7ttLaWWegmqXWRq2P1m0l2gLRRUTwJApav/aCi9HbkKNDg5lWDjZodYks
-tTbsaXfwhJWjONJfgJX+9Cqg9LvnIAzBUS5A6jwAHR5+IyA4NKByrER6j4Yd7J8DOi6QdzAofCvA5xX+
-EtxQ3cOi7nYOy0qCQxIF1dl+P41ZSwTTeKX51nuioCGpBGuTSEGzAkPaBxWqQWOx32biE3LqdBXNp5NJ
-zMWg5m8TCIVBkw67IPdIsEPyHvSvJ/Gqdk4r4rYVJlG7iQ4UnM5z6XlSSqgs8ohwcNAde/vteX8MJvfc
-9r9WOyJgBFD8VIHiyJMoA2kxCsbbV95jo+Vgr/NsEtsKVO+KNVQruY3my9YZBY3IwRNUzLzcMR3PADQA
-/hcyMWuz1e3gIGkrA4oHWuwI5lbn+lao+4G6onksypxYkz7NY1LnelapPCIgHzPwUKQDE775YgZt8RkX
-jWe0rg98r/ZVGZqnLV7fZkMxu7BqOYqrF1LQDEWSolv5FAyRdUeTWPTqGZAMaKFL9E+Z+2Q+qHYO+9UA
-eBTaQoPcIpi0QPu0nUxIh+YbbQAvhXoaO9WnnY9ZLdvVbicyMruzaPb7L6e0X4apZZTfXrq2aGhuEJ1Q
-+eDe7yilJrtdZ4LQw3DW0ED7Nf+50YL//8UPQ/F9d9Udh0mdv6tdaND5rc7Ju9qdCgwVb2Pq+syvLihl
-s5aHusbyA9GDSMwUhJY8zmCeFQ8obMyj/nVLpA+AF5QSNnuACAMYa+l1GreRjy6ZqrT/m61tuM7h9fyI
-XKlLVK57nJQuQHGJKzB2tDxtY/zV6YK0rEBZobEMnIO08ObvPtyei1U7/QEzg7ZYoMTUaXMmov9a/6ZN
-Ce47AWYB7A04XIoSzwQT2Y298RR6OSTxTMT2G/99Qq0g/15QtUKbQnU6X+uPNZpt9zgpvZI6va9FLx62
-dzen1frhjq1HU+LXq52cCZ+B1I6r6yPT6teD5EZv5JCEx8cnYR6G7/Vo9n6sdaLea8v8T1eRomULdJ74
-7aI9eFbfjHEua1ecjSHRuHNBwjBzJsYCkZ+L8ScaK7Q6F2bZ3c3jOKeBNoLn6Cxb+Aln0U04f4XD5/oE
-1eGdG39E191vEf9jxJVy/m8AAAD//5zwoONkEQAA
+H4sIAAAAAAAC/7RXXW/bNhe+jn8Fo/fmHTCabXdTDLKxLM2wAOla1MmyXR6JRxIdilRJSq5h+L8PpD6i
+uEnzYeciEUmd85xPPzqMjz98Or389/MZKVwp55P4mNIJY+RUV2sj8sKRd2/e/kLfvXn7npxwKMlng1bi
+ekpOpCRBwhKDFk2D3CteWSQ6I64QllhdmxRJqjkSYUmuGzQKOUnWxBVIPp5fEilSVBa9pivAkRQUSZBk
+ulacCBXkLs5Pz/5anJFMSJxOKJ1PYu8skaDyWYQqmk8mcYHA55OjuEQHJC3AWHSzqHYZfR8RNrwpnKso
+fq1FM4v+oVcn9FSXFTiRSIxIqpVD5WbR+dkMeY5jRQUlzqJG4KrSxo1kV4K7YsaxESnSsPmZCCWcAElt
+ChJnb7/H4WhTIyontBpBfQQhF7I2FRqy8Bk1hJJwYEkJQhKhnCY6kaIRWh1/Dwu1K7QZIY5LRmLgUP7m
+/1VdEVNdzgPKDkxV0drIEc5mM/1cJ1Kk19fXV18uttteSwp1QwzKWSRSH0thMLtHnK1WK+ZDsG14TJSQ
+o2UZNF5vKlLdIzrhJM43m+mlX2y3hDEySkzMWoHB+FMtugJLtMwD+9V2yxKtnXUGqmlqbdRGYd1aoi0Q
+XUQEn0VB6/decDF6G3L/qAeZVg5WaHWJLLU27Gl38IDZpwFL/9NL9Ld3Abbf7QU55INyAVLnAXn38FAW
+wKEBlWMl0hs0bGe/l5Vx1X0IAeFgiN/30Y/whx7abZ3NxmFZSXBIoqA63W4nMWtpbBInmq+9awoakkqw
+dhYpaBIwpH1QoRo0FvttJr4hp05X0XxydBRzMaj53zAIhUGTDrsgd0ewQ/Ie9K+P4qR2Tivi1hXOonYT
+7Sg4nefSs7yUUFnkEeHgoDv29tvz/hhM7pn5f612RMAIoPitAsWRz6IMpMUoGG9feY+NloO9zrOj2Fag
+elesoVrJdTS/bJ1R0IgcPL3GzMvdp+OJhwbA15CJWZutbgc7SUsMKB5IveO1C53rC6FuHqTQaB6LMifW
+pM/gV6lzPa1UHhGQdz8wQxV3fPDdGTNou4Nx0Xim7RrFN3NftqG72ur2fThUu4u7lqPAeyEFzVBFKbqV
+z9GDoXciR7Ho4TIgGdBCl+ifMvfZv4XqAvCrwcCTTDELDXKLYNIC7cOGMyEdmkMZBV4K9bCxVD8eXsxq
+2a42G5GR6ZVFs93+uAj9Moxxo4r00rVFQ3OD6ITKB/f+RCk12Ww6E4TuxreEBtrx5tdGC/7/Nz8N7eL7
+se5oUer8U+1Cz88vdE4+1e6xwFDxNqauM/3qmFI2bamta0U/Id6KxExBaOL7SdET7Q4rjqnZv265+Rbw
+mFLCprcQYSJlLWNP4jbyH/1OVaX933RpA2UE+flTFEtdonLd4/nqBSguMQFjR8sXeDH+GHaJsqxAWaGx
+DJyDtPAOXn25ODh47fQXzAzaYoESU6fNoU34QeQPbUpwr2UhC+gfwOGlKPHQ6CI7t+ee/E+GQhzaRDvP
+vFJ2KshfDbtWaFOoXpDz5dcazbp7PF89kTq9qUWvH7ZX5y/A6ednthxN5nvgPDqH7wPdXiKW99wh9kDN
+jV7JIZF3j5+Pe3uLWo4uUXdhntt3S8ssmkakaNkCnf922kV7sF9Dj4FPalccHlSicQdHDUPnoUEXiPzg
+oH+jsUKrg+Nedkx0P/ALkFeC5+gsW/hhddENq9fhcG+vodollPE8tOxuqv6q6ko5/y8AAP//S89c/kAU
+AAA=
 `,
 	},
 
 	"/www/mailslurper/pages/admin.gohtml": {
+		name:    "admin.gohtml",
 		local:   "www/mailslurper/pages/admin.gohtml",
-		size:    521,
-		modtime: 1517350779,
+		size:    538,
+		modtime: 1542258197,
 		compressed: `
-H4sIAAAAAAAC/2xRTWvjMBA9x79iotPuYaP7YhuWPfQUKKQUeioTa2IrVSQzM44Jxv+92AlOG3qR4D29
-D80Mg6ODjwSmEjHjmA0DRTeOWXZn9sldJip3/gxVQJHCYCBWmM8/DmNNDI13jqIB7wpzJhaf4pZEsCZT
-Zqu31DHcYEgH2KIPu9BxSwy/cmkxzsJL6vj1+sqUuZ3w8jd4gdTpJHOotIaXhqDqmCnq4uklW919buyj
-1QaeSEEbghyhYToUplFt/1p7Qh/k2mdTpZMBRa5JC/O+Dxg/TBlQSZa43GK5znLr/LnMvk2GUz/9d4am
-JuhOPu5I1cdapiKz5IF/5i7SQt6uH1ZxnHe0yqVi3yoIV4Wxfd9/rW+PYqsUlVMIxGL/TQH/F2BznFtc
-He4hnwEAAP//0Knq6AkCAAA=
+H4sIAAAAAAAC/2xRTYvbMBA9x79iolN7qHUvtqH00EsDoWkbeiqKNLGVVSQzM44Jxv99sROc3bAXCd7T
++xjNMDg8+oigLLMax2wYMLpxzLIHc0juOlGF8xewwTCXygQkgfn84kyskaDxzmFU4F2pLkjsU9wgs6lR
+VdnqX+oI7jCkI2yMD7vQUYsEnwpuTZyF19TR39srVRV6wqvP4BlSJ5PMGcE1/G4QbEeEURZPz9nq4XNn
+n61y+IEC0iAUBhrCY6kakfar1mfjA9/65DadFYihGqVU/w/BxBdVBSPIS1yhTbXOCu38pcre/Qylfpp3
+hqYmxp193KGIjzVPRWbJE7+lLuJC3q8PVnGad7Qq2JJvBZhsqYYh33aH4O1+v//z6+c46r7v386jT6xt
+ikIpBCTW36bE7wuQn+ZaN8tH6msAAAD///o3vLEaAgAA
 `,
 	},
 
 	"/www/mailslurper/pages/index.gohtml": {
+		name:    "index.gohtml",
 		local:   "www/mailslurper/pages/index.gohtml",
-		size:    211,
-		modtime: 1517350779,
+		size:    228,
+		modtime: 1542258197,
 		compressed: `
-H4sIAAAAAAAC/2yNQQ6CMBBF13IK0gM4FwA2blzIIWpnjEMGSmYQYpre3aAJ3bj8eT/vpYT04IlqF8xc
-zlVKNGHOVVXIPeJ7Rw3yWjO2bvQsN7bFdQ0gr10hRl7Ds/csfUQvx+GPdfjmTo0F5XmpTUPrYNs22O0m
-L51JYTAIcVo0ipAaXONIl2OfB9sDP0FpfAIAAP//i91Ol9MAAAA=
+H4sIAAAAAAAC/2zNTYqEQAyG4fV4CqkDWBdQN7OZhcIwMLguK2k6Ei1J/KEp6u6N3aCbXoY3fE+MgDea
+MDde1aSUxYgTpJRlV+kDPI5UAm05QWVGR9yQLqYuLdBWX0XRib+3jrgN4Ph8+LA6vLivUr3QvOQqvjIx
+Fr9rz+S7rvv/a1Ky+77bg1NeZUaxg1ofpkUCM4ranzDi93kXgx7ie/FCnwEAAP//QUjEz+QAAAA=
 `,
 	},
 
 	"/www/mailslurper/pages/login.gohtml": {
+		name:    "login.gohtml",
 		local:   "www/mailslurper/pages/login.gohtml",
-		size:    837,
-		modtime: 1526608264,
+		size:    871,
+		modtime: 1542258197,
 		compressed: `
-H4sIAAAAAAAC/4ySQa6bMBCG1+EU1uwTXwDYVF1UymuflPYABgbXke2xxia8COXulYEEKvVJ3UTze8b/
-fDH/NHXYG48CGuru8HgUZRCtVTFWYEnTsSWflPHIUBeH0jgtIrcVyHEcpVPGRjtwQJbGKY1R3pCTaZU9
-Ba9BKJsqeFPGXpYpcSZNIGRdlDLURTFNphenr8zEeXNnbs/dyiInMf8eO+X1sn+aTm8Yo9KYx2VnbnUx
-Tei7x6Moyp7YPe+PaK2wpI0/NvQBwiuHFfTszvkMhOn2ymH6TV0F7z8uP0GoNhnyFciAnD2Ps8/8/3eE
-c0czDSF3DqVVDVrRE1cwROTvyiHUvyKyyGUp5/48aXwYkkj3gBUk/EhPute1mW5T+4X5czBZEGpI1FM7
-xPyah/Ut/pswqBhH4g7q97X6DPA1uUJuOkNu6p+Qf6M1Q0rkV99FPF2b5C9D40xabHdy9W2SF03yx8DG
-Kb7PtdVQn0mLb76Ui13OVSbYpWIL+DXmeB/K2LIJ6ZMYX6Nc6S1ylHM+vrwOTtcIdSkXh23JnwAAAP//
-3MgghEUDAAA=
+H4sIAAAAAAAC/4ySzarbMBCF1/FTiNknegHbm9JFIbcNTS9Zy/ZYVZA1YiQnNwi/e5Ht/BRauJswRzM6
++jI+KXXYG4cCGupuME1F6UVrVQgVWNK0bclFZRwy1MWmNIMWgdsKUtodxsaa9nQ6vf/cT5O8Xq9yUMYG
+O7JHlmZQGoO8IEfTKrvzToNQNlbwpow9LlNiT5pAyLoopa+LIiXTi91XZuKM0pnLHUZZ5Cjm322nnF6A
+Utq9YQhKYx6XnbnURUroumkqirInHu73r2itsKSN2zb0AcKpASvoedjnMxCme1UDxt/UVXD4cfwFQrXR
+kKtAeuTsuZ195oW8EM4dzTT63NmUVjVoRU9cwRiQv6sBoX4PyCKXpZz786Rxfowi3jxWEPEj3uke12a6
+p3p9MH8fJgtCjZF6aseQt7lZd/FpQq9CuBJ3UB/W6n+Aj8kV8qkz5FP9E/JvtGaMkdzqu4i7axPdcWwG
+ExfbF7n6NtGJJrqtZzMovs211VDvSYtvrpSLXc5VJnhJxTPx55DzvilDy8bHz+b6HOT6dyxykHNgvjwO
+ducAdSkXy+erfwIAAP//Dnv7CGcDAAA=
 `,
 	},
 
 	"/www/mailslurper/pages/manageSavedSearches.gohtml": {
+		name:    "manageSavedSearches.gohtml",
 		local:   "www/mailslurper/pages/manageSavedSearches.gohtml",
-		size:    198,
-		modtime: 1517350779,
+		size:    215,
+		modtime: 1542258197,
 		compressed: `
-H4sIAAAAAAAC/2zNMa7CMAzG8fn1FFUO8HyBtgszU08QYgOOQlLZJRGKcndEkSgD81/f96sV6cyReuNU
-TWtdrRSxta7byynh45UG5NwzjkZtJpzJiruSmmkA5Dz9Wvrt8m9QJ7ysvYobDZRS4GY5aLjLQgJewaW4
-SgqBROFoo73Q/E0cPvnfb977byefAQAA//9NfHgvxgAAAA==
+H4sIAAAAAAAC/2yOQQ6CMBBF13IK0gPQCwAbt5oYiWFdOqMOqYXMAI1pencjJuLC9cv/78UIeCWPubIi
+KqUsRvSQUpZtpBvg+UYl0JITVErMgtCgYXtHUXWpgZb637JfL3elWKZxyoVtpWIsTnPnyLZtezkfUtIh
+BP0w5MTNPCLrXrQd/MSDc8iij8abGza/zv0XF/0a8BFsDa8AAAD//+vdSMHXAAAA
 `,
 	},
 
 	"/www/mailslurper/templates/adminPrune.hbs": {
+		name:    "adminPrune.hbs",
 		local:   "www/mailslurper/templates/adminPrune.hbs",
 		size:    1024,
-		modtime: 1521001643,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/4RSTYvbMBA9J79i1j20PTjeDyilOIYl7GGh7S7bLaVHWZrEYmWN0Yy9GJP/XiQnaUoL
 vdiS5s2befOmvMjzZVHAhrox2F0jcH15dZNfX159hFujWngMyA7HFdw6BwnBEJAxDGhi4ndGoC1IYxmY
@@ -17187,9 +17270,10 @@ SXctfp5QdnJkzj8vf/jPv18BAAD//7mvKl8ABAAA
 	},
 
 	"/www/mailslurper/templates/adminSettings.hbs": {
+		name:    "adminSettings.hbs",
 		local:   "www/mailslurper/templates/adminSettings.hbs",
 		size:    927,
-		modtime: 1521001643,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/6SSwYrbMBCGz8lTTHXXepNA6cExhO0WFtpSmu0DyNY4EpU1RhobTMi7F8sO8TalUHrJ
 zJ/5/vEPo/ydlOssgydqh2BPhmH7uNnJ7ePmAxy0auBbwOhweICDc5CICAEjhh71aPwREagGNjZCpC5U
@@ -17203,22 +17287,24 @@ AAA=
 	},
 
 	"/www/mailslurper/templates/helpers/attachmentURL.js": {
+		name:    "attachmentURL.js",
 		local:   "www/mailslurper/templates/helpers/attachmentURL.js",
-		size:    403,
-		modtime: 1526607268,
+		size:    355,
+		modtime: 1542252866,
 		compressed: `
-H4sIAAAAAAAC/3SN0WryQBBGr/88xUeuEvybqL0peCUiKNhStD7AujtJBtZdmZ1EpPTdi2IRCr2bOecM
-U9dYxNNFuO0U0/Hk+Wk6nrxg7swR70LJ06XC3HvcigShRDKQy+oa+0SIDbTjhBR7sQQbHYET2jiQBHI4
-XKAd4XX9Ac+WQqLrpXZGYU3AgdDEPjhwuHWb9WL5tluiYU9VlveJkFTYaj7LspUJztPBSKqEWk5KsiJ/
-Iilyo2psd6Sg++0m/4+mD1Y5BhQPU+Iz+yekvQScObh4rnakyqFNO5KBLVUt6X3cbzfFH5GQCtNA9/1H
-F2WJEfL6aNjXOUZ4fK6ubO1u+kF/R+xm2Vc5y74DAAD///xoTQqTAQAA
+H4sIAAAAAAAC/1yMwWrCQBRF181XXLJSbBO1m4IrEUHBlqL1A8aZm2RgnJE3L4qU/ntRCkJ3j3POu3WN
+RTpdxbedYjqevL5Mx5M3zJ054lOYA68V5iHgXmQIM+VMV9Q19plIDbTzGTn1YgmbHOEz2nSmRDocrtCO
+eF9/IXjLmHn71M4orIk4EE3qo4OP926zXiw/dks0PrAqyj4TWcVbLWdFsTLRBR6M5ErY+qyUFcOJMiiN
+qrHdkVH32035jKaPVn2KGDzMEN/Fk1B7ibj46NKl2lHVxzbvKGdvWbXUv3O/3QyGGKGsj8aHusQIj6Xq
+xtburh/0f+TdrPgZzorfAAAA//+tloJ0YwEAAA==
 `,
 	},
 
 	"/www/mailslurper/templates/helpers/autoRefreshSelector.js": {
+		name:    "autoRefreshSelector.js",
 		local:   "www/mailslurper/templates/helpers/autoRefreshSelector.js",
 		size:    716,
-		modtime: 1521001643,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/2yRUW/TMBSFn+tfceSnVt3Sbrwg0oCqadImwUAUeKE8uPZNY8m1q2sno0L77yhOV1a0
 N8fnfOce38xmuAn7A9ttk3A9v3pzeT2/eoulUTt8YYqODgWWziE7IpgicUdGzGb4HgmhRmpsRAwta4IO
@@ -17232,9 +17318,10 @@ AP//OQqe+swCAAA=
 	},
 
 	"/www/mailslurper/templates/helpers/dateFormatSelector.js": {
+		name:    "dateFormatSelector.js",
 		local:   "www/mailslurper/templates/helpers/dateFormatSelector.js",
 		size:    785,
-		modtime: 1521001643,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/4yRwW7bPBCEz+ZTDHiy4UR28l9+VFaLIEmRAG1awO2p7oEmVxYBijSWlFOjyLsXolwn
 qVGgt5V25tud5WyG67Dds900CZfzi//OL+cX/+PKqBafmaKjfYEr55AVEUyReEdGzGb4GgmhRmpsRAwd
@@ -17248,9 +17335,10 @@ KcWvAAAA//+r0HD/EQMAAA==
 	},
 
 	"/www/mailslurper/templates/helpers/formatDateTime.js": {
+		name:    "formatDateTime.js",
 		local:   "www/mailslurper/templates/helpers/formatDateTime.js",
 		size:    351,
-		modtime: 1521001643,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/0TN0araQBDG8Wv3KT5ylUCbqL0phF6ItSi0paB9gDX7JVlIdmV2EpHDefeDysHLGX7/
 marCNl5u4rtesV6uvn1dL1ffsXF2xD9hGngrsRkGPESCMFFmOlNV+J+I2EJ7n5DiJA3RREf4hC7OlECH
@@ -17261,9 +17349,10 @@ zUKokwSMcWTQ5/ny+T9/uaI270VtPgIAAP//wV3ynF8BAAA=
 	},
 
 	"/www/mailslurper/templates/helpers/ifIsImageAttachment.js": {
+		name:    "ifIsImageAttachment.js",
 		local:   "www/mailslurper/templates/helpers/ifIsImageAttachment.js",
 		size:    491,
-		modtime: 1521001643,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/2yQUYvTQBSFnzO/4pCnFrrJdn0RikJZChuwKrg+iQ/TmTPJ6HQmzJ0Ei+x/l0bQXfTx
 HL5z+bhti/s0XrLvh4K72+2rm7vb7WvsrT7jY6YEXhrsQ8BCCDKFeaZVbYvPQiSHMniBpCkbwiRLeEGf
@@ -17275,9 +17364,10 @@ CvMDw8i8qr3rpDvrnvtStBnOjKXewE3RFJ8iVvpPvcEpJPN9jZ+qmnXGrIO3y/TYHQ+Pl5GCN/iiqqr2
 	},
 
 	"/www/mailslurper/templates/helpers/pageSelector.js": {
+		name:    "pageSelector.js",
 		local:   "www/mailslurper/templates/helpers/pageSelector.js",
 		size:    594,
-		modtime: 1521001643,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/1SQQWvbQBCFz95f8diTjRwrTi+lslJCCCTQhkDamy/r1UhaWO2a2ZGpKfnvRZIb5Nto
 9OZ7722e4zEez+yaVnB3u/1yc3e7/YqHynR4Y0qezhs8eI9RkcCUiE9UqTzH70SINaR1CSn2bAk2VgSX
@@ -17290,9 +17380,10 @@ T1eoj1Wh/gUAAP//zzXtDVICAAA=
 	},
 
 	"/www/mailslurper/templates/helpers/themeSelector.js": {
+		name:    "themeSelector.js",
 		local:   "www/mailslurper/templates/helpers/themeSelector.js",
 		size:    686,
-		modtime: 1521001643,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/2yRUWvbMBSFn6NfcdBTQlon7V7GHG+UUmhhK4N0T8seHOk4FshSkOR0YfS/D8tZaGBv
 ku/57v18tVjg3u+PwezahNvlzYfr2+XNR9zpusP3wGh5LHBnLXIiIjAyHKjFYoEfkfANUmsiou+DIpTX
@@ -17305,9 +17396,10 @@ jfx3HEZ9wmXLcQXn62U7V3e8CK8Wo3uG3oR4XxmnDBUxCUx9cPl9SvE2K8XfAAAA//+Z3aDsrgIAAA==
 	},
 
 	"/www/mailslurper/templates/helpers/unescape.js": {
+		name:    "unescape.js",
 		local:   "www/mailslurper/templates/helpers/unescape.js",
 		size:    813,
-		modtime: 1521001643,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/3TR32vbMBAH8Gfrr/iiQpfQzE6bMda6GZRSaGEbg25PXWGKdbYFiuSd5LBQ8r+PpGYk
 QX2zpc+d7kdR4NZ3azZNG3ExPZ+9v5ief8KNVkt8ZwqW1jlurMVOBDAF4hVpURT4GQi+RmxNQPA9V4TK
@@ -17320,9 +17412,10 @@ nqdd/HM+dHbQz//LvbPxUOdQ98EDpdiMS/EvAAD//z9HpLwtAwAA
 	},
 
 	"/www/mailslurper/templates/mailDetails.hbs": {
+		name:    "mailDetails.hbs",
 		local:   "www/mailslurper/templates/mailDetails.hbs",
 		size:    1011,
-		modtime: 1521001643,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/6SS0WvbMBDGn62/4uayR8dtx2AUxRBKB4G2jLV9HmfrYmuTpaJT0gXh/31ITsjoSl/2
 YmHp0+/0fXfyQ1WJuoZr97z3uh8CXJ5ffKouzy++wErhCN88saH9AlbGQFYweGLyO1Lp4hMTuA2EQTOw
@@ -17337,9 +17430,10 @@ luXJyp1TaHIL3ji8djYkJ42sld4lwLzOy58AAAD//zirgHbzAwAA
 	},
 
 	"/www/mailslurper/templates/mailList.hbs": {
+		name:    "mailList.hbs",
 		local:   "www/mailslurper/templates/mailList.hbs",
 		size:    4156,
-		modtime: 1521001643,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/6xX71LcNhD/DE+xdSb5VOMDkrYTfMykJJkykzBMoA+wZ61ttbLkSmvgxnPv3pFln33H
 ASHkC7eW9s9v/2pJf4nj/SSBM1MvrSxKhqPZ4XF8NDv8Az4IrODSklO0PIAPSkHH4cCSI3tDwgv+7QhM
@@ -17367,9 +17461,10 @@ zR2jzypaibHCBal51ImFas89eYkFrdM9zIwNBf0y1ykppRA0j9g2FJ12qrY2ua3nfeuJv1/OU48uLd1I
 	},
 
 	"/www/mailslurper/templates/manageSavedSearches.hbs": {
+		name:    "manageSavedSearches.hbs",
 		local:   "www/mailslurper/templates/manageSavedSearches.hbs",
 		size:    1160,
-		modtime: 1521001643,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/4STT2+cPBDGz8unmJecvc4f6VUVEdQ0TdVITVVp00OPBg/g1nhWtiFFFt+9MpDd0CTq
 Bc2Mf8/o2dmZ7D/GEs7hhvaDVXXj4fz07IKdn569g2spWvhm0WkctnCtNUyEA4sObY8yCr87BKrAN8qB
@@ -17385,9 +17480,10 @@ rqpx/BMAAP//CwAdaYgEAAA=
 	},
 
 	"/www/mailslurper/templates/saveSearchModal.hbs": {
+		name:    "saveSearchModal.hbs",
 		local:   "www/mailslurper/templates/saveSearchModal.hbs",
 		size:    315,
-		modtime: 1521001643,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/1SMQWrrMBRFx9+ruF9zxUlKoRTbEEIGgTYU0i5Alp4tgSwZ6dnYuy/2rJM7ueec6r+U
 RVniGsc1ud4yzsfTizwfT2+4GDXgK1H2tB5w8R47kZEoU5rJbOJPJsQObF1GjlPSBB0NwWX0caYUyKBd
@@ -17398,9 +17494,10 @@ c/MbAAD//++PtUc7AQAA
 	},
 
 	"/www/mailslurper/templates/savedSearchesModal.hbs": {
+		name:    "savedSearchesModal.hbs",
 		local:   "www/mailslurper/templates/savedSearchesModal.hbs",
 		size:    383,
-		modtime: 1521001643,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/1yNwUrDQBRF18lXXOM6TVs3Immw1C4KKkL1A6YzL83AdF6ZNwmWMP8uaTfq8sI599R3
 ZZlXFTZ8vgR77CKW88VDuZwvHrE26oSPQOLoMsPaOVwJQSChMJCZxC8hcIvYWYFwHzRBsyFYwZEHCp4M
@@ -17411,9 +17508,10 @@ OpBDy2FViBrI7EkF3e1eimY/Tdz2U11dwckQcqQjrPlv/Clo9jGwmxrZON6T0h1+4SQp5VmW1XyOlj0G
 	},
 
 	"/www/mailslurper/templates/searchMailModal.hbs": {
+		name:    "searchMailModal.hbs",
 		local:   "www/mailslurper/templates/searchMailModal.hbs",
 		size:    1100,
-		modtime: 1521001643,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/5SS324TPRDFr7NPMZ8vvjt326AiBBtLVSlSJQqIhAfwn9mswbFX9mxI3h7ZSZNs1KBy
 5Xhy5sz5zbr5j/OqruE+9Ntolx3B9PrmDZ9e37yDOyNX8C1icri9gjvnoCgSREwY12hy44+EEFqgziZI
@@ -17428,9 +17526,10 @@ AA==
 	},
 
 	"/www/mailslurper/themes/default/bootstrap.css": {
+		name:    "bootstrap.css",
 		local:   "www/mailslurper/themes/default/bootstrap.css",
 		size:    146082,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/+y9a4/kOJIg+D1+hToLhcqscinl8ld4JCpv5noXOw1Mz4fbPmCB6roDXaK71CmX1JI8
 HtUb+9sPEkWJDzOS8vDMmlt0xUxnhGhmNJoZjcaX8eOPf7jzfvT+z7Jsm7Ymlfe4ClbB1nuftm318PHj
@@ -17787,18 +17886,20 @@ P979fwEAAP//RKe1DKI6AgA=
 	},
 
 	"/www/mailslurper/themes/default/style.css": {
+		name:    "style.css",
 		local:   "www/mailslurper/themes/default/style.css",
 		size:    0,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/wEAAP//AAAAAAAAAAA=
 `,
 	},
 
 	"/www/mailslurper/themes/lumen/bootstrap.css": {
+		name:    "bootstrap.css",
 		local:   "www/mailslurper/themes/lumen/bootstrap.css",
 		size:    156000,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/+y9/Y/kuJEg+nv9FdoeGNPtTmkk5VdlNabPd77DrYHzYgH7hwPG8x6YEjNT00pJlpT1
 MXN1f/uDRFHiRwRJZWW3dx/cteupEiOCwWAwGAySwT9k56qsW+9S5+/fndq2ah5++OFQFm0THMvymFNS
@@ -18176,18 +18277,20 @@ YGECAA==
 	},
 
 	"/www/mailslurper/themes/lumen/style.css": {
+		name:    "style.css",
 		local:   "www/mailslurper/themes/lumen/style.css",
 		size:    0,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/wEAAP//AAAAAAAAAAA=
 `,
 	},
 
 	"/www/mailslurper/themes/readable/bootstrap.css": {
+		name:    "bootstrap.css",
 		local:   "www/mailslurper/themes/readable/bootstrap.css",
 		size:    148828,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/+y9a4/kuLEg+r1+hU4NBtPtTqkl5aMqqzG9PutdnGNgbVx4/WGB8dwLpsTM1LRSkiVl
 PWa29rdf6EHxFUFSWdlt3IuZOsddJUYEg8FgMBgkg3/MTlVZt965zt/dHtu2ah4+ftyXRdsEh7I85JRU
@@ -18551,9 +18654,10 @@ gRi4oP1VWsbfU4Bu7k47Cto3LW09oGqCBIY0cCaY/zcAAP//KWsQ81xFAgA=
 	},
 
 	"/www/mailslurper/themes/readable/style.css": {
+		name:    "style.css",
 		local:   "www/mailslurper/themes/readable/style.css",
 		size:    78,
-		modtime: 1527564863,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/9JLyk+p1E3OzytJzMxLLVKo5uLMTSxKz8zTLckvsFIwMymosOaq5VLOTczM8SxJzS12
 zs8pzc0DqStITEnJzEvXLcpMzyixUjCw5qoFBAAA///OZT//TgAAAA==
@@ -18561,9 +18665,10 @@ zs8pzc0DqStITEnJzEvXLcpMzyixUjCw5qoFBAAA///OZT//TgAAAA==
 	},
 
 	"/www/mailslurper/themes/slate/bootstrap.css": {
+		name:    "bootstrap.css",
 		local:   "www/mailslurper/themes/slate/bootstrap.css",
 		size:    168207,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/+z9bY/ktpIgCn+vX6Fpw3D3cWZaUr5Xw/3M7Oxi5wB7Bg+w58MCPr4XTIlZKbdS0pGU
 1dX21v72C4mkxJcIksrK6jNzb9kzx5ViRDAYEQwG34I//emf7oI/BYeybJsvpE1OweNysVxsuo//Vp5p
@@ -18948,9 +19053,10 @@ uD8qrJaBva/r6c//TwAAAP//YXMPoQ+RAgA=
 	},
 
 	"/www/mailslurper/themes/slate/style.css": {
+		name:    "style.css",
 		local:   "www/mailslurper/themes/slate/style.css",
 		size:    68,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/9LLTczM0c3JLC7RLcov183ITM/IyUzPKFGo5uJMSkzOTi/KL81L0U3Oz8kvslJQNk+0
 MLKwUFDMzC3ILypJzCux5qrlAgQAAP//06LQO0QAAAA=
@@ -18958,9 +19064,10 @@ MLKwUFDMzC3ILypJzCux5qrlAgQAAP//06LQO0QAAAA=
 	},
 
 	"/www/mailslurper/themes/spacelab/bootstrap.css": {
+		name:    "bootstrap.css",
 		local:   "www/mailslurper/themes/spacelab/bootstrap.css",
 		size:    155976,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/+y9a4/cyLEg+r1/BY8Gg5GsYg3JKtajhdGeXe9ij4H1ORewPywwnnuRRWZV0WKRNMnq
 bs1s72+/YD7IfEQ+WN0t770YyR51M+OVkZGRka/Ify0uTd32wbUt3787933T3f/447Gu+m55qutTiVFT
@@ -19337,18 +19444,20 @@ ttJO+/P/GwAA//+OhOapSGECAA==
 	},
 
 	"/www/mailslurper/themes/spacelab/style.css": {
+		name:    "style.css",
 		local:   "www/mailslurper/themes/spacelab/style.css",
 		size:    0,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/wEAAP//AAAAAAAAAAA=
 `,
 	},
 
 	"/www/moment/moment.js": {
+		name:    "moment.js",
 		local:   "www/moment/moment.js",
 		size:    101906,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/+y9bXvbOJIo+j2/ovLsdJOM9Wo7TrcctR9vnLc5cZJpOzebyBovLUISOxSpJago6lbm
 t98HBYAEQICSu+ecez7cnt1YJKsKQAEoFAqFqm73ISyyBUmLzm/0AXv6SnIaZykM4LDT73WO8GW4KuZZ
@@ -19751,9 +19860,10 @@ y4cVDC2lCTBhAxGQpw8efA+C0/83AAD//z+CtpoSjgEA
 	},
 
 	"/www/npo/npo.js": {
+		name:    "npo.js",
 		local:   "www/npo/npo.js",
 		size:    4323,
-		modtime: 1517350779,
+		modtime: 1542249883,
 		compressed: `
 H4sIAAAAAAAC/7xXQW/bOBO951c86xCQDas43+mDXK2xhz0Uu9sWaG9GEKgyZXMhkwZFJTVS//fFkKJM
 JfZugQV6ikXODGfezLyZ3L6Z4UPl1KPEJ2t2qpP4qNvDFQA8zvP/5/O3FVjN8fuhlfisdvvOaH/75/sv
@@ -19783,203 +19893,483 @@ WGQJG+MQAAA=
 `,
 	},
 
-	"/": {
-		isDir: true,
-		local: "www",
-	},
-
 	"/www": {
+		name:  "www",
+		local: `./www`,
 		isDir: true,
-		local: "www/www",
 	},
 
 	"/www/blockui": {
+		name:  "blockui",
+		local: `www/blockui`,
 		isDir: true,
-		local: "www/www/blockui",
 	},
 
 	"/www/bootstrap": {
+		name:  "bootstrap",
+		local: `www/bootstrap`,
 		isDir: true,
-		local: "www/www/bootstrap",
 	},
 
 	"/www/bootstrap-daterangepicker": {
+		name:  "bootstrap-daterangepicker",
+		local: `www/bootstrap-daterangepicker`,
 		isDir: true,
-		local: "www/www/bootstrap-daterangepicker",
 	},
 
 	"/www/bootstrap-dialog": {
+		name:  "bootstrap-dialog",
+		local: `www/bootstrap-dialog`,
 		isDir: true,
-		local: "www/www/bootstrap-dialog",
 	},
 
 	"/www/bootstrap-dialog/css": {
+		name:  "css",
+		local: `www/bootstrap-dialog/css`,
 		isDir: true,
-		local: "www/www/bootstrap-dialog/css",
 	},
 
 	"/www/bootstrap-dialog/js": {
+		name:  "js",
+		local: `www/bootstrap-dialog/js`,
 		isDir: true,
-		local: "www/www/bootstrap-dialog/js",
 	},
 
 	"/www/bootstrap-growl": {
+		name:  "bootstrap-growl",
+		local: `www/bootstrap-growl`,
 		isDir: true,
-		local: "www/www/bootstrap-growl",
 	},
 
 	"/www/bootstrap/css": {
+		name:  "css",
+		local: `www/bootstrap/css`,
 		isDir: true,
-		local: "www/www/bootstrap/css",
 	},
 
 	"/www/bootstrap/fonts": {
+		name:  "fonts",
+		local: `www/bootstrap/fonts`,
 		isDir: true,
-		local: "www/www/bootstrap/fonts",
 	},
 
 	"/www/bootstrap/js": {
+		name:  "js",
+		local: `www/bootstrap/js`,
 		isDir: true,
-		local: "www/www/bootstrap/js",
 	},
 
 	"/www/fontawesome": {
+		name:  "fontawesome",
+		local: `www/fontawesome`,
 		isDir: true,
-		local: "www/www/fontawesome",
 	},
 
 	"/www/fontawesome/css": {
+		name:  "css",
+		local: `www/fontawesome/css`,
 		isDir: true,
-		local: "www/www/fontawesome/css",
 	},
 
 	"/www/fontawesome/fonts": {
+		name:  "fonts",
+		local: `www/fontawesome/fonts`,
 		isDir: true,
-		local: "www/www/fontawesome/fonts",
 	},
 
 	"/www/handlebars": {
+		name:  "handlebars",
+		local: `www/handlebars`,
 		isDir: true,
-		local: "www/www/handlebars",
 	},
 
 	"/www/jquery": {
+		name:  "jquery",
+		local: `www/jquery`,
 		isDir: true,
-		local: "www/www/jquery",
 	},
 
 	"/www/lightbox2": {
+		name:  "lightbox2",
+		local: `www/lightbox2`,
 		isDir: true,
-		local: "www/www/lightbox2",
 	},
 
 	"/www/lightbox2/css": {
+		name:  "css",
+		local: `www/lightbox2/css`,
 		isDir: true,
-		local: "www/www/lightbox2/css",
 	},
 
 	"/www/lightbox2/images": {
+		name:  "images",
+		local: `www/lightbox2/images`,
 		isDir: true,
-		local: "www/www/lightbox2/images",
 	},
 
 	"/www/lightbox2/js": {
+		name:  "js",
+		local: `www/lightbox2/js`,
 		isDir: true,
-		local: "www/www/lightbox2/js",
 	},
 
 	"/www/mailslurper": {
+		name:  "mailslurper",
+		local: `www/mailslurper`,
 		isDir: true,
-		local: "www/www/mailslurper",
 	},
 
 	"/www/mailslurper/css": {
+		name:  "css",
+		local: `www/mailslurper/css`,
 		isDir: true,
-		local: "www/www/mailslurper/css",
 	},
 
 	"/www/mailslurper/images": {
+		name:  "images",
+		local: `www/mailslurper/images`,
 		isDir: true,
-		local: "www/www/mailslurper/images",
 	},
 
 	"/www/mailslurper/js": {
+		name:  "js",
+		local: `www/mailslurper/js`,
 		isDir: true,
-		local: "www/www/mailslurper/js",
 	},
 
 	"/www/mailslurper/js/controllers": {
+		name:  "controllers",
+		local: `www/mailslurper/js/controllers`,
 		isDir: true,
-		local: "www/www/mailslurper/js/controllers",
 	},
 
 	"/www/mailslurper/js/services": {
+		name:  "services",
+		local: `www/mailslurper/js/services`,
 		isDir: true,
-		local: "www/www/mailslurper/js/services",
 	},
 
 	"/www/mailslurper/js/widgets": {
+		name:  "widgets",
+		local: `www/mailslurper/js/widgets`,
 		isDir: true,
-		local: "www/www/mailslurper/js/widgets",
 	},
 
 	"/www/mailslurper/layouts": {
+		name:  "layouts",
+		local: `www/mailslurper/layouts`,
 		isDir: true,
-		local: "www/www/mailslurper/layouts",
 	},
 
 	"/www/mailslurper/pages": {
+		name:  "pages",
+		local: `www/mailslurper/pages`,
 		isDir: true,
-		local: "www/www/mailslurper/pages",
 	},
 
 	"/www/mailslurper/templates": {
+		name:  "templates",
+		local: `www/mailslurper/templates`,
 		isDir: true,
-		local: "www/www/mailslurper/templates",
 	},
 
 	"/www/mailslurper/templates/helpers": {
+		name:  "helpers",
+		local: `www/mailslurper/templates/helpers`,
 		isDir: true,
-		local: "www/www/mailslurper/templates/helpers",
 	},
 
 	"/www/mailslurper/themes": {
+		name:  "themes",
+		local: `www/mailslurper/themes`,
 		isDir: true,
-		local: "www/www/mailslurper/themes",
 	},
 
 	"/www/mailslurper/themes/default": {
+		name:  "default",
+		local: `www/mailslurper/themes/default`,
 		isDir: true,
-		local: "www/www/mailslurper/themes/default",
 	},
 
 	"/www/mailslurper/themes/lumen": {
+		name:  "lumen",
+		local: `www/mailslurper/themes/lumen`,
 		isDir: true,
-		local: "www/www/mailslurper/themes/lumen",
 	},
 
 	"/www/mailslurper/themes/readable": {
+		name:  "readable",
+		local: `www/mailslurper/themes/readable`,
 		isDir: true,
-		local: "www/www/mailslurper/themes/readable",
 	},
 
 	"/www/mailslurper/themes/slate": {
+		name:  "slate",
+		local: `www/mailslurper/themes/slate`,
 		isDir: true,
-		local: "www/www/mailslurper/themes/slate",
 	},
 
 	"/www/mailslurper/themes/spacelab": {
+		name:  "spacelab",
+		local: `www/mailslurper/themes/spacelab`,
 		isDir: true,
-		local: "www/www/mailslurper/themes/spacelab",
 	},
 
 	"/www/moment": {
+		name:  "moment",
+		local: `www/moment`,
 		isDir: true,
-		local: "www/www/moment",
 	},
 
 	"/www/npo": {
+		name:  "npo",
+		local: `www/npo`,
 		isDir: true,
-		local: "www/www/npo",
+	},
+}
+
+var _escDirs = map[string][]os.FileInfo{
+
+	"./www": {
+		_escData["/www/blockui"],
+		_escData["/www/bootstrap"],
+		_escData["/www/bootstrap-daterangepicker"],
+		_escData["/www/bootstrap-dialog"],
+		_escData["/www/bootstrap-growl"],
+		_escData["/www/fontawesome"],
+		_escData["/www/handlebars"],
+		_escData["/www/jquery"],
+		_escData["/www/lightbox2"],
+		_escData["/www/mailslurper"],
+		_escData["/www/moment"],
+		_escData["/www/npo"],
+	},
+
+	"www/blockui": {
+		_escData["/www/blockui/jquery.blockUI.js"],
+	},
+
+	"www/bootstrap": {
+		_escData["/www/bootstrap/css"],
+		_escData["/www/bootstrap/fonts"],
+		_escData["/www/bootstrap/js"],
+	},
+
+	"www/bootstrap-daterangepicker": {
+		_escData["/www/bootstrap-daterangepicker/daterangepicker.css"],
+		_escData["/www/bootstrap-daterangepicker/daterangepicker.js"],
+	},
+
+	"www/bootstrap-dialog": {
+		_escData["/www/bootstrap-dialog/css"],
+		_escData["/www/bootstrap-dialog/js"],
+	},
+
+	"www/bootstrap-dialog/css": {
+		_escData["/www/bootstrap-dialog/css/bootstrap-dialog.css"],
+	},
+
+	"www/bootstrap-dialog/js": {
+		_escData["/www/bootstrap-dialog/js/bootstrap-dialog.js"],
+	},
+
+	"www/bootstrap-growl": {
+		_escData["/www/bootstrap-growl/jquery.bootstrap-growl.js"],
+	},
+
+	"www/bootstrap/css": {
+		_escData["/www/bootstrap/css/bootstrap-theme.css"],
+		_escData["/www/bootstrap/css/bootstrap-theme.css.map"],
+		_escData["/www/bootstrap/css/bootstrap.css"],
+		_escData["/www/bootstrap/css/bootstrap.css.map"],
+	},
+
+	"www/bootstrap/fonts": {
+		_escData["/www/bootstrap/fonts/glyphicons-halflings-regular.eot"],
+		_escData["/www/bootstrap/fonts/glyphicons-halflings-regular.svg"],
+		_escData["/www/bootstrap/fonts/glyphicons-halflings-regular.ttf"],
+		_escData["/www/bootstrap/fonts/glyphicons-halflings-regular.woff"],
+		_escData["/www/bootstrap/fonts/glyphicons-halflings-regular.woff2"],
+	},
+
+	"www/bootstrap/js": {
+		_escData["/www/bootstrap/js/bootstrap.js"],
+	},
+
+	"www/fontawesome": {
+		_escData["/www/fontawesome/css"],
+		_escData["/www/fontawesome/fonts"],
+	},
+
+	"www/fontawesome/css": {
+		_escData["/www/fontawesome/css/font-awesome.css"],
+		_escData["/www/fontawesome/css/font-awesome.css.map"],
+	},
+
+	"www/fontawesome/fonts": {
+		_escData["/www/fontawesome/fonts/FontAwesome.otf"],
+		_escData["/www/fontawesome/fonts/fontawesome-webfont.eot"],
+		_escData["/www/fontawesome/fonts/fontawesome-webfont.svg"],
+		_escData["/www/fontawesome/fonts/fontawesome-webfont.ttf"],
+		_escData["/www/fontawesome/fonts/fontawesome-webfont.woff"],
+		_escData["/www/fontawesome/fonts/fontawesome-webfont.woff2"],
+	},
+
+	"www/handlebars": {
+		_escData["/www/handlebars/handlebars.amd.js"],
+		_escData["/www/handlebars/handlebars.js"],
+		_escData["/www/handlebars/handlebars.runtime.amd.js"],
+		_escData["/www/handlebars/handlebars.runtime.js"],
+	},
+
+	"www/jquery": {
+		_escData["/www/jquery/jquery.js"],
+	},
+
+	"www/lightbox2": {
+		_escData["/www/lightbox2/css"],
+		_escData["/www/lightbox2/images"],
+		_escData["/www/lightbox2/js"],
+	},
+
+	"www/lightbox2/css": {
+		_escData["/www/lightbox2/css/lightbox.css"],
+	},
+
+	"www/lightbox2/images": {
+		_escData["/www/lightbox2/images/close.png"],
+		_escData["/www/lightbox2/images/loading.gif"],
+		_escData["/www/lightbox2/images/next.png"],
+		_escData["/www/lightbox2/images/prev.png"],
+	},
+
+	"www/lightbox2/js": {
+		_escData["/www/lightbox2/js/lightbox-plus-jquery.js"],
+		_escData["/www/lightbox2/js/lightbox.js"],
+	},
+
+	"www/mailslurper": {
+		_escData["/www/mailslurper/css"],
+		_escData["/www/mailslurper/images"],
+		_escData["/www/mailslurper/js"],
+		_escData["/www/mailslurper/layouts"],
+		_escData["/www/mailslurper/pages"],
+		_escData["/www/mailslurper/templates"],
+		_escData["/www/mailslurper/themes"],
+	},
+
+	"www/mailslurper/css": {
+		_escData["/www/mailslurper/css/login.css"],
+		_escData["/www/mailslurper/css/style.css"],
+	},
+
+	"www/mailslurper/images": {
+		_escData["/www/mailslurper/images/favicon.ico"],
+		_escData["/www/mailslurper/images/logo.png"],
+		_escData["/www/mailslurper/images/vertical.png"],
+	},
+
+	"www/mailslurper/js": {
+		_escData["/www/mailslurper/js/app.js"],
+		_escData["/www/mailslurper/js/controllers"],
+		_escData["/www/mailslurper/js/services"],
+		_escData["/www/mailslurper/js/widgets"],
+	},
+
+	"www/mailslurper/js/controllers": {
+		_escData["/www/mailslurper/js/controllers/AdminController.js"],
+		_escData["/www/mailslurper/js/controllers/HomeController.js"],
+		_escData["/www/mailslurper/js/controllers/LoginController.js"],
+		_escData["/www/mailslurper/js/controllers/ManageSavedSearchesController.js"],
+	},
+
+	"www/mailslurper/js/services": {
+		_escData["/www/mailslurper/js/services/AlertService.js"],
+		_escData["/www/mailslurper/js/services/AuthService.js"],
+		_escData["/www/mailslurper/js/services/MailService.js"],
+		_escData["/www/mailslurper/js/services/SeedService.js"],
+		_escData["/www/mailslurper/js/services/SettingsService.js"],
+		_escData["/www/mailslurper/js/services/TemplateService.js"],
+		_escData["/www/mailslurper/js/services/VersionService.js"],
+	},
+
+	"www/mailslurper/js/widgets": {
+		_escData["/www/mailslurper/js/widgets/SavedSearchesWidget.js"],
+	},
+
+	"www/mailslurper/layouts": {
+		_escData["/www/mailslurper/layouts/loginLayout.gohtml"],
+		_escData["/www/mailslurper/layouts/mainLayout.gohtml"],
+	},
+
+	"www/mailslurper/pages": {
+		_escData["/www/mailslurper/pages/admin.gohtml"],
+		_escData["/www/mailslurper/pages/index.gohtml"],
+		_escData["/www/mailslurper/pages/login.gohtml"],
+		_escData["/www/mailslurper/pages/manageSavedSearches.gohtml"],
+	},
+
+	"www/mailslurper/templates": {
+		_escData["/www/mailslurper/templates/adminPrune.hbs"],
+		_escData["/www/mailslurper/templates/adminSettings.hbs"],
+		_escData["/www/mailslurper/templates/helpers"],
+		_escData["/www/mailslurper/templates/mailDetails.hbs"],
+		_escData["/www/mailslurper/templates/mailList.hbs"],
+		_escData["/www/mailslurper/templates/manageSavedSearches.hbs"],
+		_escData["/www/mailslurper/templates/saveSearchModal.hbs"],
+		_escData["/www/mailslurper/templates/savedSearchesModal.hbs"],
+		_escData["/www/mailslurper/templates/searchMailModal.hbs"],
+	},
+
+	"www/mailslurper/templates/helpers": {
+		_escData["/www/mailslurper/templates/helpers/attachmentURL.js"],
+		_escData["/www/mailslurper/templates/helpers/autoRefreshSelector.js"],
+		_escData["/www/mailslurper/templates/helpers/dateFormatSelector.js"],
+		_escData["/www/mailslurper/templates/helpers/formatDateTime.js"],
+		_escData["/www/mailslurper/templates/helpers/ifIsImageAttachment.js"],
+		_escData["/www/mailslurper/templates/helpers/pageSelector.js"],
+		_escData["/www/mailslurper/templates/helpers/themeSelector.js"],
+		_escData["/www/mailslurper/templates/helpers/unescape.js"],
+	},
+
+	"www/mailslurper/themes": {
+		_escData["/www/mailslurper/themes/default"],
+		_escData["/www/mailslurper/themes/lumen"],
+		_escData["/www/mailslurper/themes/readable"],
+		_escData["/www/mailslurper/themes/slate"],
+		_escData["/www/mailslurper/themes/spacelab"],
+	},
+
+	"www/mailslurper/themes/default": {
+		_escData["/www/mailslurper/themes/default/bootstrap.css"],
+		_escData["/www/mailslurper/themes/default/style.css"],
+	},
+
+	"www/mailslurper/themes/lumen": {
+		_escData["/www/mailslurper/themes/lumen/bootstrap.css"],
+		_escData["/www/mailslurper/themes/lumen/style.css"],
+	},
+
+	"www/mailslurper/themes/readable": {
+		_escData["/www/mailslurper/themes/readable/bootstrap.css"],
+		_escData["/www/mailslurper/themes/readable/style.css"],
+	},
+
+	"www/mailslurper/themes/slate": {
+		_escData["/www/mailslurper/themes/slate/bootstrap.css"],
+		_escData["/www/mailslurper/themes/slate/style.css"],
+	},
+
+	"www/mailslurper/themes/spacelab": {
+		_escData["/www/mailslurper/themes/spacelab/bootstrap.css"],
+		_escData["/www/mailslurper/themes/spacelab/style.css"],
+	},
+
+	"www/moment": {
+		_escData["/www/moment/moment.js"],
+	},
+
+	"www/npo": {
+		_escData["/www/npo/npo.js"],
 	},
 }

--- a/pkg/mailslurper/Configuration.go
+++ b/pkg/mailslurper/Configuration.go
@@ -23,8 +23,10 @@ servers and connect to databases.
 type Configuration struct {
 	WWWAddress       string `json:"wwwAddress"`
 	WWWPort          int    `json:"wwwPort"`
+	WWWPublicURL     string `json:"wwwPublicURL"`
 	ServiceAddress   string `json:"serviceAddress"`
 	ServicePort      int    `json:"servicePort"`
+	ServicePublicURL string `json:"servicePublicURL"`
 	SMTPAddress      string `json:"smtpAddress"`
 	SMTPPort         int    `json:"smtpPort"`
 	DBEngine         string `json:"dbEngine"`
@@ -114,6 +116,10 @@ func (config *Configuration) GetFullWWWBindingAddress() string {
 GetPublicServiceURL returns a full protocol, address, and port for the MailSlurper service
 */
 func (config *Configuration) GetPublicServiceURL() string {
+	if config.ServicePublicURL != "" {
+		return config.ServicePublicURL
+	}
+
 	result := "http"
 
 	if config.CertFile != "" && config.KeyFile != "" {
@@ -128,6 +134,10 @@ func (config *Configuration) GetPublicServiceURL() string {
 GetPublicWWWURL returns a full protocol, address and port for the web application
 */
 func (config *Configuration) GetPublicWWWURL() string {
+	if config.WWWPublicURL != "" {
+		return config.WWWPublicURL
+	}
+
 	result := "http"
 
 	if config.AdminCertFile != "" && config.AdminKeyFile != "" {

--- a/pkg/mailslurper/Configuration.go
+++ b/pkg/mailslurper/Configuration.go
@@ -116,7 +116,7 @@ GetPublicWWWRoot returns a full protocol, address and port for the web applicati
 func (config *Configuration) GetPublicWWWRoot() string {
 	result := "http"
 
-	if config.CertFile != "" && config.KeyFile != "" {
+	if config.AdminCertFile != "" && config.AdminKeyFile != "" {
 		result += "s"
 	}
 

--- a/pkg/mailslurper/Configuration.go
+++ b/pkg/mailslurper/Configuration.go
@@ -111,6 +111,20 @@ func (config *Configuration) GetFullWWWBindingAddress() string {
 }
 
 /*
+GetPublicServiceURL returns a full protocol, address, and port for the MailSlurper service
+*/
+func (config *Configuration) GetPublicServiceURL() string {
+	result := "http"
+
+	if config.CertFile != "" && config.KeyFile != "" {
+		result += "s"
+	}
+
+	result += fmt.Sprintf("://%s:%d", config.ServiceAddress, config.ServicePort)
+	return result
+}
+
+/*
 GetPublicWWWRoot returns a full protocol, address and port for the web application
 */
 func (config *Configuration) GetPublicWWWRoot() string {

--- a/pkg/mailslurper/Configuration.go
+++ b/pkg/mailslurper/Configuration.go
@@ -125,9 +125,9 @@ func (config *Configuration) GetPublicServiceURL() string {
 }
 
 /*
-GetPublicWWWRoot returns a full protocol, address and port for the web application
+GetPublicWWWURL returns a full protocol, address and port for the web application
 */
-func (config *Configuration) GetPublicWWWRoot() string {
+func (config *Configuration) GetPublicWWWURL() string {
 	result := "http"
 
 	if config.AdminCertFile != "" && config.AdminKeyFile != "" {

--- a/pkg/mailslurper/Configuration.go
+++ b/pkg/mailslurper/Configuration.go
@@ -111,9 +111,9 @@ func (config *Configuration) GetFullWWWBindingAddress() string {
 }
 
 /*
-GetCORSWWWAddress returns a full protocol, address and port for the web application
+GetPublicWWWRoot returns a full protocol, address and port for the web application
 */
-func (config *Configuration) GetCORSWWWAddress() string {
+func (config *Configuration) GetPublicWWWRoot() string {
 	result := "http"
 
 	if config.CertFile != "" && config.KeyFile != "" {

--- a/pkg/mailslurper/Page.go
+++ b/pkg/mailslurper/Page.go
@@ -8,10 +8,10 @@ package mailslurper
 A Page is the basis for all displayed HTML pages
 */
 type Page struct {
-	PublicWWWRoot string
-	Error         bool
-	Message       string
-	Theme         string
-	Title         string
-	User          string
+	PublicWWWURL string
+	Error        bool
+	Message      string
+	Theme        string
+	Title        string
+	User         string
 }

--- a/pkg/mailslurper/Page.go
+++ b/pkg/mailslurper/Page.go
@@ -8,9 +8,10 @@ package mailslurper
 A Page is the basis for all displayed HTML pages
 */
 type Page struct {
-	Error   bool
-	Message string
-	Theme   string
-	Title   string
-	User    string
+	PublicWWWRoot string
+	Error         bool
+	Message       string
+	Theme         string
+	Title         string
+	User          string
 }

--- a/pkg/mailslurper/ServiceSettings.go
+++ b/pkg/mailslurper/ServiceSettings.go
@@ -10,8 +10,6 @@ and talk to the MailSlurper service tier.
 */
 type ServiceSettings struct {
 	AuthenticationScheme string `json:"authenticationScheme"`
-	IsSSL                bool   `json:"isSSL"`
-	ServiceAddress       string `json:"serviceAddress"`
-	ServicePort          int    `json:"servicePort"`
+	URL                  string `json:"url"`
 	Version              string `json:"version"`
 }


### PR DESCRIPTION
Adds support for reverse proxying by introducing (optional) `wwwPublicURL` and `servicePublicURL` config values that are then used to prefix assets for the web app, as well as ajax calls.

Closes #92

I've tested with the following config:

_nginx.conf_
```nginx
server {
    server_name mail.dev;
    listen 80;

    location / {
        proxy_pass http://localhost:8080;
    }

    location /api/ {
      proxy_pass http://localhost:8085/;
    }
  }
```

_config.json_
```json
{
  "wwwPublicURL": "http://mail.dev",
  "servicePublicURL": "http://mail.dev/api",

  ...defaults...
}
```