### PR TITLE
Implement SMTP RSET command

### DIFF
--- a/pkg/mailslurper/MailCommandExecutor.go
+++ b/pkg/mailslurper/MailCommandExecutor.go
@@ -58,14 +58,17 @@ func (e *MailCommandExecutor) Process(streamInput string, mailItem *MailItem) er
 		return err
 	}
 
-	if fromComponents, err = e.emailValidationService.GetEmailComponents(from); err != nil {
-		return InvalidEmail(from)
-	}
+	// For all we know, <> is a valid email address (RFC 2821, Section 6.1 & 3.7; NULL return path)
+	if from != "<>" {
+		if fromComponents, err = e.emailValidationService.GetEmailComponents(from); err != nil {
+			return InvalidEmail(from)
+		}
 
-	from = e.xssService.SanitizeString(fromComponents.Address)
+		from = e.xssService.SanitizeString(fromComponents.Address)
 
-	if !e.emailValidationService.IsValidEmail(from) {
-		return InvalidEmail(from)
+		if !e.emailValidationService.IsValidEmail(from) {
+			return InvalidEmail(from)
+		}
 	}
 
 	mailItem.FromAddress = from

--- a/pkg/mailslurper/ResetCommandExecutor.go
+++ b/pkg/mailslurper/ResetCommandExecutor.go
@@ -1,0 +1,43 @@
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+
+package mailslurper
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+/*
+ResetCommandExecutor process the command RSET
+*/
+type ResetCommandExecutor struct {
+	logger *logrus.Entry
+	writer *SMTPWriter
+}
+
+/*
+NewResetCommandExecutor creates a new struct
+*/
+func NewResetCommandExecutor(logger *logrus.Entry, writer *SMTPWriter) *ResetCommandExecutor {
+	return &ResetCommandExecutor{
+		logger: logger,
+		writer: writer,
+	}
+}
+
+/*
+Process handles the RSET command
+*/
+func (e *ResetCommandExecutor) Process(streamInput string, mailItem *MailItem) error {
+	if strings.ToLower(streamInput) != "rset" {
+		return fmt.Errorf("Invalid RSET command")
+	}
+
+	// Overwrite current mail object with an empty one
+	*mailItem = *NewEmptyMailItem(e.logger)
+
+	return e.writer.SendOkResponse()
+}

--- a/pkg/mailslurper/SMTPWorker.go
+++ b/pkg/mailslurper/SMTPWorker.go
@@ -255,6 +255,12 @@ func (smtpWorker *SMTPWorker) getExecutorFromCommand(command SMTPCommand) IComma
 			smtpWorker.XSSService,
 		)
 
+	case RSET:
+		return NewResetCommandExecutor(
+			GetLogger(smtpWorker.logLevel, smtpWorker.logFormat, "RSET Command Executor"),
+			smtpWorker.Writer,
+		)
+
 	default:
 		return NewHelloCommandExecutor(
 			GetLogger(smtpWorker.logLevel, smtpWorker.logFormat, "HELO Command Executor"),


### PR DESCRIPTION
Hi!

This PR implements the SMTP RSET command, as specified in RFC 5321, Section 4.1.1.5.
Also fixes handling of NULL return paths; described in RFC RFC 2821, Section 6.1 & 3.7.