### PR TITLE
Implement SMTP NOOP command

### DIFF
--- a/pkg/mailslurper/NoopCommandExecutor.go
+++ b/pkg/mailslurper/NoopCommandExecutor.go
@@ -1,0 +1,44 @@
+// Use of this source code is governed by the MIT license
+// that can be found in the LICENSE file.
+
+package mailslurper
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+/*
+NoopCommandExecutor process the command NOOP
+*/
+type NoopCommandExecutor struct {
+	logger *logrus.Entry
+	writer *SMTPWriter
+}
+
+/*
+NewNoopCommandExecutor creates a new struct
+*/
+func NewNoopCommandExecutor(logger *logrus.Entry, writer *SMTPWriter) *NoopCommandExecutor {
+	return &NoopCommandExecutor{
+		logger: logger,
+		writer: writer,
+	}
+}
+
+/*
+Process handles the NOOP command
+*/
+func (e *NoopCommandExecutor) Process(streamInput string, mailItem *MailItem) error {
+	var err error
+
+	//validate
+	if err = IsValidCommand(streamInput, "NOOP"); err != nil {
+		return err
+	}
+
+	//log the command, and do nothing
+	e.logger.Debugf("NOOP command received")
+
+	//Response: 250 Ok
+	return e.writer.SendOkResponse()
+}

--- a/pkg/mailslurper/SMTPWorker.go
+++ b/pkg/mailslurper/SMTPWorker.go
@@ -260,6 +260,12 @@ func (smtpWorker *SMTPWorker) getExecutorFromCommand(command SMTPCommand) IComma
 			GetLogger(smtpWorker.logLevel, smtpWorker.logFormat, "RSET Command Executor"),
 			smtpWorker.Writer,
 		)
+	case NOOP:
+		return NewNoopCommandExecutor(
+			GetLogger(smtpWorker.logLevel, smtpWorker.logFormat, "NOOP Command Executor"),
+			smtpWorker.Writer,
+		)
+
 
 	default:
 		return NewHelloCommandExecutor(

--- a/pkg/mailslurper/SmtpCommands.go
+++ b/pkg/mailslurper/SmtpCommands.go
@@ -26,6 +26,7 @@ const (
 	RSET SMTPCommand = iota
 	DATA SMTPCommand = iota
 	QUIT SMTPCommand = iota
+	NOOP SMTPCommand = iota
 )
 
 /*
@@ -43,6 +44,7 @@ var SMTPCommands = map[string]SMTPCommand{
 	"rset":      RSET,
 	"quit":      QUIT,
 	"data":      DATA,
+	"noop":      NOOP,
 }
 
 /*
@@ -56,6 +58,7 @@ var SMTPCommandsToStrings = map[SMTPCommand]string{
 	RSET: "RSET",
 	QUIT: "QUIT",
 	DATA: "DATA",
+	NOOP: "NOOP",
 }
 
 /*


### PR DESCRIPTION
This PR adds support for `NOOP`, and resolves mailslurper/mailslurper#102.

Use case: The default Java SMTP transport implementation's connection testing logic "pings" the server with a `NOOP` command (or `RSET`, if explicitly configured)