### PR TITLE
Update Docker build & add quickstart to README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:alpine as builder
+FROM golang:1.18.1-alpine3.15 as builder
 
 LABEL maintainer="erguotou525@gmail.compute"
 
 RUN apk --no-cache add git libc-dev gcc
-RUN go get github.com/mjibson/esc
+RUN go install github.com/mjibson/esc@latest # TODO: Consider using native file embedding
 
 COPY . /go/src/github.com/mailslurper/mailslurper
 WORKDIR /go/src/github.com/mailslurper/mailslurper/cmd/mailslurper
@@ -12,7 +12,7 @@ RUN go get
 RUN go generate
 RUN go build
 
-FROM alpine:3.6
+FROM alpine:3.15
 
 RUN apk add --no-cache ca-certificates \
  && echo -e '{\n\

--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ $ go generate
 $ go build
 ```
 
+Quickstart With Docker
+----------------------
+
+```bash
+# Build container image (adjust repo location as necessary)
+docker build -t mailslurper 'https://github.com/mailslurper/mailslurper#master'
+# Run a temporary container. Note that upon shutdown, all stored messages will be lost when using this config.
+docker run -it --rm --name mailslurper -p 8080:8080 -p 8085:8085 -p 2500:2500 mailslurper
+```
+
 Library and Framework Credits
 -----------------------------
 This application uses a lot of great open source libraries.


### PR DESCRIPTION
This change has two goals:
- Enable Docker container to build using a recent version of Go, while pinning the version to help ensure it doesn't accidentally break in the future
- Add a quick start section to help folks try this out with minimal effort using Docker

Also, thanks for the great project 🎉  Please let me know if you'd like to see any changes 🙂 