### PR TITLE
Publish official AMD64/ARM64 image to GitHub Container Registry

### DIFF
--- a/.github/workflows/image-build-push.yaml
+++ b/.github/workflows/image-build-push.yaml
@@ -1,0 +1,73 @@
+name: Image Build Push
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  build:
+    permissions:
+      contents: read
+    concurrency:
+      group: ${{ github.ref_name }}
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          provenance: false
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha,scope=buildx-multi-arch
+          cache-to: type=gha,scope=buildx-multi-arch,mode=max
+
+  push:
+    if: ${{ github.ref_type == 'tag' }}
+    needs:
+      - build
+    permissions:
+      contents: read
+      packages: write
+    concurrency:
+      group: ${{ github.ref_name }}
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          cache-from: type=gha,scope=buildx-multi-arch
+          cache-to: type=gha,scope=buildx-multi-arch,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,44 +1,51 @@
-FROM golang:1.18.1-alpine3.15 as builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.19.13-alpine3.18 as builder
+
+ARG TARGETOS TARGETARCH
 
 LABEL maintainer="erguotou525@gmail.compute"
 
-RUN apk --no-cache add git libc-dev gcc
-RUN go install github.com/mjibson/esc@latest # TODO: Consider using native file embedding
+RUN apk --no-cache add git libc-dev gcc ca-certificates
+RUN go install github.com/mjibson/esc@v0.2.0
+
+RUN ls "$GOPATH/bin"
 
 COPY . /go/src/github.com/mailslurper/mailslurper
 WORKDIR /go/src/github.com/mailslurper/mailslurper/cmd/mailslurper
+
+ENV GOOS=$TARGETOS GOARCH=$TARGETARCH
 
 RUN go get
 RUN go generate
 RUN go build
 
-FROM alpine:3.15
+RUN <<EOF
+echo -e '{
+  "wwwAddress": "0.0.0.0",
+  "wwwPort": 8080,
+  "wwwPublicURL": "",
+  "serviceAddress": "0.0.0.0",
+  "servicePort": 8085,
+  "servicePublicURL": "",
+  "smtpAddress": "0.0.0.0",
+  "smtpPort": 2500,
+  "dbEngine": "SQLite",
+  "dbHost": "",
+  "dbPort": 0,
+  "dbDatabase": "./mailslurper.db",
+  "dbUserName": "",
+  "dbPassword": "",
+  "maxWorkers": 1000,
+  "autoStartBrowser": false,
+  "keyFile": "",
+  "certFile": "",
+  "adminKeyFile": "",
+  "adminCertFile": ""
+}' >> config.json
+EOF
 
-RUN apk add --no-cache ca-certificates \
- && echo -e '{\n\
-  "wwwAddress": "0.0.0.0",\n\
-  "wwwPort": 8080,\n\
-  "wwwPublicURL": "",\n\
-  "serviceAddress": "0.0.0.0",\n\
-  "servicePort": 8085,\n\
-  "servicePublicURL": "",\n\
-  "smtpAddress": "0.0.0.0",\n\
-  "smtpPort": 2500,\n\
-  "dbEngine": "SQLite",\n\
-  "dbHost": "",\n\
-  "dbPort": 0,\n\
-  "dbDatabase": "./mailslurper.db",\n\
-  "dbUserName": "",\n\
-  "dbPassword": "",\n\
-  "maxWorkers": 1000,\n\
-  "autoStartBrowser": false,\n\
-  "keyFile": "",\n\
-  "certFile": "",\n\
-  "adminKeyFile": "",\n\
-  "adminCertFile": ""\n\
-  }'\
-  >> config.json
+FROM gcr.io/distroless/static-debian12
 
+COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 COPY --from=builder /go/src/github.com/mailslurper/mailslurper/cmd/mailslurper/mailslurper mailslurper
 
 EXPOSE 8080 8085 2500

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,45 @@
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.19.13-alpine3.18 as builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.21.1-bookworm as builder
 
-ARG TARGETOS TARGETARCH
+ARG ESC_VERSION="v0.2.0"
 
 LABEL maintainer="erguotou525@gmail.compute"
 
-RUN apk --no-cache add git libc-dev gcc ca-certificates
-RUN go install github.com/mjibson/esc@v0.2.0
+ARG TARGETOS TARGETARCH
 
-RUN ls "$GOPATH/bin"
+RUN dpkg --add-architecture "${TARGETARCH}"
+RUN apt update
+RUN <<EOF
+case "${TARGETARCH}" in
+  "amd64")
+    CC_PACKAGE="gcc-x86-64-linux-gnu" ;;
+  "arm64")
+    CC_PACKAGE="gcc-aarch64-linux-gnu" ;;
+esac
+apt install --yes "$CC_PACKAGE" git libc-dev ca-certificates libsqlite3-dev:"${TARGETARCH}"
+EOF
+
+RUN go install github.com/mjibson/esc@"${ESC_VERSION}"
 
 COPY . /go/src/github.com/mailslurper/mailslurper
 WORKDIR /go/src/github.com/mailslurper/mailslurper/cmd/mailslurper
 
-ENV GOOS=$TARGETOS GOARCH=$TARGETARCH
+ENV GOOS="${TARGETOS}" GOARCH="${TARGETARCH}" CGO_ENABLED=1
 
 RUN go get
 RUN go generate
-RUN go build
+RUN <<EOF
+case "${TARGETARCH}" in
+  "amd64")
+    CC_NAME="x86_64-linux-gnu-gcc" ;;
+  "arm64")
+    CC_NAME="aarch64-linux-gnu-gcc" ;;
+esac
+CC="$CC_NAME" go build -o /out/mailslurper
+EOF
+RUN
 
 RUN <<EOF
-echo -e '{
+echo '{
   "wwwAddress": "0.0.0.0",
   "wwwPort": 8080,
   "wwwPublicURL": "",
@@ -40,14 +60,15 @@ echo -e '{
   "certFile": "",
   "adminKeyFile": "",
   "adminCertFile": ""
-}' >> config.json
+}' > /out/config.json
 EOF
 
-FROM gcr.io/distroless/static-debian12
+FROM gcr.io/distroless/base-debian12
 
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
-COPY --from=builder /go/src/github.com/mailslurper/mailslurper/cmd/mailslurper/mailslurper mailslurper
+COPY --from=builder /out/mailslurper /bin/mailslurper
+COPY --from=builder /out/config.json /etc/mailslurper/config.json
 
 EXPOSE 8080 8085 2500
 
-CMD ["./mailslurper"]
+CMD ["/bin/mailslurper", "--config", "/etc/mailslurper/config.json"]

--- a/README.md
+++ b/README.md
@@ -28,10 +28,7 @@ Quickstart With Docker
 ----------------------
 
 ```bash
-# Build container image (adjust repo location as necessary)
-docker build -t mailslurper 'https://github.com/mailslurper/mailslurper#master'
-# Run a temporary container. Note that upon shutdown, all stored messages will be lost when using this config.
-docker run -it --rm --name mailslurper -p 8080:8080 -p 8085:8085 -p 2500:2500 mailslurper
+docker run -it --rm --name mailslurper -p 8080:8080 -p 8085:8085 -p 2500:2500 ghcr.io/mailslurper/mailslurper
 ```
 
 Library and Framework Credits


### PR DESCRIPTION
Hi, and thanks for the cool project! I've started publishing a multi-arch image to my fork's packages and wanted to upstream the GitHub action in case that was helpful.

The resulting [published registry entry looks like this](https://github.com/thebearingedge/mailslurper/pkgs/container/mailslurper).

Builds are meant run on any PR to `master`, but publishes are meant to only run by pushing a tag.

```shell
git tag 2.0.0         # or whatever the new version is
git push origin 2.0.0 # or whatever the new version is
```

Cross compilation was used instead of Qemu emulation to keep building snappy.

I used a [distroless image](https://github.com/GoogleContainerTools/distroless) in the final build stage, but admittedly, I did this just because it seems to be "best practice" these days, so I can't say I have a good argument to do it that way.

Happy to make adjustments here, and also happy to help if changes are needed when v2 comes out.

Thanks!