### PR TITLE
feat: Add Docker Compose support and fix Dockerfile build issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  mailslurper:
+    build: .
+    container_name: mailslurper
+    ports:
+      - "8080:8080"  # Web UI
+      - "8085:8085"  # Service API
+      - "2500:2500"  # SMTP
+    volumes:
+      - ./data:/app/data  # Persist database
+    environment:
+      - WWW_ADDRESS=0.0.0.0
+      - WWW_PORT=8080
+      - SERVICE_ADDRESS=0.0.0.0
+      - SERVICE_PORT=8085
+      - SMTP_ADDRESS=0.0.0.0
+      - SMTP_PORT=2500
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s

--- a/send_test_email.py
+++ b/send_test_email.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""
+Simple script to send test emails to MailSlurper
+"""
+
+import smtplib
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
+from datetime import datetime
+import sys
+
+def send_test_email(smtp_host='localhost', smtp_port=2500, 
+                   from_addr='test@example.com', to_addr='recipient@example.com',
+                   subject='Test Email from Python Script'):
+    """Send a test email to MailSlurper"""
+    
+    # Email body
+    body = f"""Hello from MailSlurper Test!
+
+This is a test email sent from a Python script at {datetime.now()}.
+
+MailSlurper should capture this email and display it in the web interface.
+
+Features tested:
+- SMTP connection to MailSlurper
+- Email capture and storage
+- Web interface display
+
+Best regards,
+Python Test Script"""
+
+    # Create the email message
+    msg = MIMEMultipart()
+    msg['From'] = from_addr
+    msg['To'] = to_addr
+    msg['Subject'] = subject
+    msg.attach(MIMEText(body, 'plain'))
+
+    # Send the email
+    print(f'Sending email to MailSlurper at {smtp_host}:{smtp_port}...')
+    print(f'From: {from_addr}')
+    print(f'To: {to_addr}')
+    print(f'Subject: {subject}')
+
+    try:
+        server = smtplib.SMTP(smtp_host, smtp_port)
+        server.send_message(msg)
+        server.quit()
+        print('\n✅ Email sent successfully!')
+        print('📧 Check MailSlurper web interface at: http://localhost:8080')
+        print('🔧 Service API available at: http://localhost:8085')
+        return True
+    except Exception as e:
+        print(f'\n❌ Error sending email: {e}')
+        return False
+
+if __name__ == '__main__':
+    # Allow custom parameters via command line
+    if len(sys.argv) > 1:
+        to_addr = sys.argv[1]
+    else:
+        to_addr = 'recipient@example.com'
+    
+    send_test_email(to_addr=to_addr)


### PR DESCRIPTION
- Add docker-compose.yml for easy development setup
- Fix Dockerfile dependency compatibility issues (esc v0.2.0 requires Go 1.24.0)
- Simplify Dockerfile to use Alpine-based build with compatible dependencies
- Add send_test_email.py utility script for testing email functionality
- Maintain all original functionality while fixing build failures

Fixes: Original Dockerfile fails to build due to esc@v0.2.0 requiring Go 1.24.0
Enhancement: Docker Compose makes project more accessible to developer
Testing: Includes Simple Python script for easy email testing